### PR TITLE
chore(deps): upgrade DetourModKit to v3.3.0

### DIFF
--- a/TPVToggle/docs/NEXT_CHANGELOG.md
+++ b/TPVToggle/docs/NEXT_CHANGELOG.md
@@ -1,5 +1,4 @@
-## [Title for next release]
+## Updated to DetourModKit v3.3.0
 
-- New feature
-- Bug fix
-- Improvement
+- Updated the mod's underlying framework (DetourModKit) to v3.3.0 for better stability and future compatibility.
+- Maintenance update only — no changes to settings, controls, or behavior. Existing configurations keep working as-is.

--- a/TPVToggle/src/config.cpp
+++ b/TPVToggle/src/config.cpp
@@ -171,7 +171,7 @@ Config loadConfig(const std::string &ini_filename)
     // Set profile directory if not set by DMKConfig
     if (config.profile_directory.empty())
     {
-        config.profile_directory = DMKFilesystem::get_runtime_directory();
+        config.profile_directory = DMKFilesystem::get_runtime_directory_utf8();
         if (config.profile_directory.empty())
         {
             config.profile_directory = ".";

--- a/TPVToggle/src/dllmain.cpp
+++ b/TPVToggle/src/dllmain.cpp
@@ -314,7 +314,7 @@ DWORD WINAPI MainThread([[maybe_unused]] LPVOID hModule_param)
         logger.enable_async_mode();
 
         // Initialize memory cache with defaults (256 entries, 50ms expiry)
-        DMKMemory::init_cache();
+        (void)DMKMemory::init_cache();
         logger.info("Memory cache system initialized");
 
         // Create exit event for thread signaling

--- a/TPVToggle/src/hooks/event_hooks.cpp
+++ b/TPVToggle/src/hooks/event_hooks.cpp
@@ -169,8 +169,8 @@ bool initializeEventHooks(uintptr_t module_base, size_t module_size)
                         logger.log(LogLevel::Info, "EventHooks: Hold-to-scroll feature enabled, applying NOP by default");
                         if (DMKMemory::write_bytes(g_accumulatorWriteAddress,
                                                    reinterpret_cast<const std::byte *>(NOP_PATTERN),
-                                                   Constants::ACCUMULATOR_WRITE_INSTR_LENGTH,
-                                                   DMKLogger::get_instance()).has_value())
+                                                   Constants::ACCUMULATOR_WRITE_INSTR_LENGTH)
+                                .has_value())
                         {
                             g_accumulatorWriteNOPped.store(true);
                         }
@@ -226,8 +226,8 @@ void cleanupEventHooks()
         logger.log(LogLevel::Info, "EventHooks: Restoring original accumulator write bytes...");
         if (!DMKMemory::write_bytes(g_accumulatorWriteAddress,
                                     g_originalAccumulatorWriteBytes,
-                                    Constants::ACCUMULATOR_WRITE_INSTR_LENGTH,
-                                    DMKLogger::get_instance()).has_value())
+                                    Constants::ACCUMULATOR_WRITE_INSTR_LENGTH)
+                 .has_value())
         {
             logger.log(LogLevel::Error, "EventHooks: FAILED TO RESTORE ACCUMULATOR WRITE BYTES!");
         }

--- a/TPVToggle/src/hooks/ui_overlay_hooks.cpp
+++ b/TPVToggle/src/hooks/ui_overlay_hooks.cpp
@@ -212,8 +212,8 @@ bool handleHoldToScrollKeyState(bool holdKeyPressed)
     {
         if (DMKMemory::write_bytes(g_accumulatorWriteAddress,
                                    g_originalAccumulatorWriteBytes,
-                                   Constants::ACCUMULATOR_WRITE_INSTR_LENGTH,
-                                   DMKLogger::get_instance()).has_value())
+                                   Constants::ACCUMULATOR_WRITE_INSTR_LENGTH)
+                .has_value())
         {
             g_accumulatorWriteNOPped.store(false);
             logger.log(LogLevel::Debug, "UIOverlayHook: Restored accumulator write due to hold key press");
@@ -225,8 +225,8 @@ bool handleHoldToScrollKeyState(bool holdKeyPressed)
     {
         if (DMKMemory::write_bytes(g_accumulatorWriteAddress,
                                    reinterpret_cast<const std::byte *>(nopSequence),
-                                   Constants::ACCUMULATOR_WRITE_INSTR_LENGTH,
-                                   DMKLogger::get_instance()).has_value())
+                                   Constants::ACCUMULATOR_WRITE_INSTR_LENGTH)
+                .has_value())
         {
             g_accumulatorWriteNOPped.store(true);
             logger.log(LogLevel::Debug, "UIOverlayHook: NOPped accumulator write due to hold key release");
@@ -301,8 +301,8 @@ bool initializeUiOverlayHooks(uintptr_t module_base, size_t module_size)
             logger.log(LogLevel::Info, "UIOverlayHook: Hold-to-scroll feature enabled, applying NOP by default");
             if (DMKMemory::write_bytes(g_accumulatorWriteAddress,
                                       reinterpret_cast<const std::byte *>(nopSequence),
-                                      Constants::ACCUMULATOR_WRITE_INSTR_LENGTH,
-                                      DMKLogger::get_instance()).has_value())
+                                      Constants::ACCUMULATOR_WRITE_INSTR_LENGTH)
+                    .has_value())
             {
                 g_accumulatorWriteNOPped.store(true);
             }
@@ -346,8 +346,7 @@ void cleanupUiOverlayHooks()
         logger.log(LogLevel::Info, "UIOverlayHook: Restoring accumulator write before exit");
         (void)DMKMemory::write_bytes(g_accumulatorWriteAddress,
                                      g_originalAccumulatorWriteBytes,
-                                     Constants::ACCUMULATOR_WRITE_INSTR_LENGTH,
-                                     DMKLogger::get_instance());
+                                     Constants::ACCUMULATOR_WRITE_INSTR_LENGTH);
         g_accumulatorWriteNOPped.store(false);
     }
 


### PR DESCRIPTION
## Summary

Upgrades the DetourModKit submodule from v2.1.0 (`75cec25`) to **v3.3.0** and adapts the few breaking API changes. Maintenance only, no user-facing behavior, settings, or controls change.
