### PR TITLE
fix(tpvcamera): stop free-look orbit self-spin

### DIFF
--- a/TPVCamera/docs/NEXT_CHANGELOG.md
+++ b/TPVCamera/docs/NEXT_CHANGELOG.md
@@ -1,5 +1,4 @@
-## [Title for next release]
+## Free-Look Orbit Fixes
 
-- New feature
-- Bug fix
-- Improvement
+- Fixed the free-look orbit camera sometimes spinning on its own and not stopping until you opened a menu
+- Fixed your character sometimes turning on its own after combat while free-look was on

--- a/TPVCamera/src/global_state.hpp
+++ b/TPVCamera/src/global_state.hpp
@@ -140,6 +140,13 @@ namespace TPVCamera
         float orbit_steer_smooth{0.0f};
         bool orbit_steer_valid{false};
 
+        // Orbit move-detection re-arm latch (render thread only). A genuine sub-stop movement-input reading must
+        // be observed since orbit engaged before a move-start is honoured, so a stranded input latch (a held-move
+        // release swallowed on a combat action-map swap) cannot re-trip the body-turn with the keys released.
+        // Cleared when orbit disengages so re-engaging requires a fresh, observed press. Pairs with
+        // player_onaction_reset() (which drops the stale latch outright on the suspend/disengage edges).
+        bool orbit_move_armed{false};
+
         // Dynamic eye-height sync (render thread only). When DynamicEyeSync is on, eye_sync_applied is the
         // eased effective eye height: it re-anchors to the REAL first-person eye when a low pose (kneel /
         // pray, and other poses EyeHeight does not model) drops it OUT of range of the configured height,

--- a/TPVCamera/src/hooks/camera_hook.cpp
+++ b/TPVCamera/src/hooks/camera_hook.cpp
@@ -1046,10 +1046,44 @@ static void offset_game_view_camera(uintptr_t camera, uintptr_t cview, uintptr_t
     {
         bool moving = cam.orbit_moving;
         const float move_magnitude = player_onaction_move_magnitude();
+        // Re-arm guard: a genuine release (magnitude below the stop threshold) must be observed since orbit
+        // engaged before a move-start is honoured. A stranded latch -- a held-move release swallowed on a
+        // combat action-map swap (see player_onaction_reset) -- reads > 0 with the keys up; without this guard
+        // it would re-trip orbit_moving the instant orbit restores and drive the body-turn with no input (the
+        // post-combat self-rotation). Arming only on a sub-stop reading means a fresh, observed press engages it.
+        static bool s_stale_suppress_logged = false;
+        if (move_magnitude < k_orbit_move_input_stop)
+        {
+            cam.orbit_move_armed = true;
+            s_stale_suppress_logged = false;
+        }
         if (!moving && move_magnitude > k_orbit_move_input_start)
         {
-            moving = true;
-            do_align = true; // idle -> moving edge: capture the camera heading
+            if (cam.orbit_move_armed)
+            {
+                moving = true;
+                do_align = true; // idle -> moving edge: capture the camera heading
+                // Diagnostic: what tripped the body-turn. move_magnitude near 1.0 with a movement key/stick =
+                // genuine locomotion; a smaller or unexpected value while the player is only free-looking
+                // points at game-driven movement (finishing-move / combat footwork) being mistaken for intent.
+                // state is the debounced GameState mask (see game_state.hpp) so we can tell whether a combat /
+                // aiming / cinematic state was active when the body-turn engaged.
+                DMK::Logger::get_instance().trace(
+                    "Orbit: move-orbit START (body-turn engaging) -- move_magnitude={:.2f}, continuous_align={}, "
+                    "state_mask=0x{:X}",
+                    move_magnitude, cfg.orbit_continuous_align.load(std::memory_order_relaxed),
+                    game_state_mask().load(std::memory_order_relaxed));
+            }
+            else if (!s_stale_suppress_logged)
+            {
+                // Unarmed (no release seen since orbit engaged) yet reading as movement: a stranded latch.
+                // Suppress the body-turn re-trip and log it once -- the diagnostic for the post-combat case.
+                DMK::Logger::get_instance().trace(
+                    "Orbit: suppressed a stale move re-trip (magnitude {:.2f}, no release observed since orbit "
+                    "engaged; likely a movement latch stranded by a combat action-map swap)",
+                    move_magnitude);
+                s_stale_suppress_logged = true;
+            }
         }
         else if (moving && move_magnitude < k_orbit_move_input_stop)
         {
@@ -1063,12 +1097,15 @@ static void offset_game_view_camera(uintptr_t camera, uintptr_t cview, uintptr_t
             // Bake the world-stable orbit angle back into the accumulator so free-look resumes from
             // exactly where the moving camera was, with no jump the instant movement stops.
             cam.orbit_yaw.store(orbit_yaw_deg, std::memory_order_relaxed);
+            DMK::Logger::get_instance().trace("Orbit: move-orbit STOP (body-turn releasing) -- move_magnitude={:.2f}",
+                                              move_magnitude);
         }
         cam.orbit_moving = moving;
     }
     else
     {
         cam.orbit_moving = false;
+        cam.orbit_move_armed = false; // require a fresh observed release after re-engaging orbit
     }
 
     // Capture the heading on move-start. Use the camera's POSITIONAL world yaw -- the eye-look yaw plus
@@ -1141,11 +1178,11 @@ static void offset_game_view_camera(uintptr_t camera, uintptr_t cview, uintptr_t
         s_body_turn_engaged = body_turn_active;
         if (body_turn_active)
         {
-            DMK::Logger::get_instance().debug("Camera: orbit body-turn ENGAGED (moving; heading locked to camera)");
+            DMK::Logger::get_instance().trace("Camera: orbit body-turn ENGAGED (moving; heading locked to camera)");
         }
         else
         {
-            DMK::Logger::get_instance().debug("Camera: orbit body-turn released");
+            DMK::Logger::get_instance().trace("Camera: orbit body-turn released");
         }
     }
     if (body_turn_active)
@@ -1481,7 +1518,15 @@ static void apply_orbit_exclude_policy(CameraState &cam, uint32_t state, uint32_
     }
     if (excluded)
     {
-        // Entering an excluded state: if free-look was on, turn it off and remember to restore it.
+        // Entering an excluded state (combat, dialogue, minigame) swaps the action map, which can swallow a
+        // held-move release and strand the movement-input latch > 0. Drop it now so when free-look restores on
+        // exit it cannot re-trip the body-turn with the keys released (the post-combat self-rotation). Logged
+        // with the cleared magnitude so the trace shows whether the latch WAS actually stranded.
+        const float stranded = player_onaction_reset();
+        DMK::Logger::get_instance().trace("Orbit: exclude-state entered; cleared move-latch (had magnitude "
+                                          "{:.2f}{})",
+                                          stranded, stranded > k_orbit_move_input_stop ? ", WAS STRANDED" : "");
+        // If free-look was on, turn it off and remember to restore it.
         s_suspended_orbit = cam.orbit_active.load(std::memory_order_relaxed);
         if (s_suspended_orbit)
         {
@@ -1644,8 +1689,26 @@ static void detour_frustum_build_impl(uintptr_t camera)
     s_offset_active.store(offset_engaged, std::memory_order_relaxed);
     reassert_head_visibility(offset_engaged);
 
+    // Edge tracker for the disengage cleanup below: true while the offset is rendering, so the cleanup runs
+    // ONCE on the third-person -> first-person transition, not every first-person frame.
+    static bool s_orbit_was_engaged = false;
     if (!offset_engaged)
     {
+        if (s_orbit_was_engaged)
+        {
+            // Just left third person (toggled to FPV, or a state suppressed the offset). Drop the orbit
+            // run-state so re-engaging is fresh: clear the move re-arm latch and force-clear any
+            // movement-input latch the game may have stranded on an action-map swap. Edge-gated so a key
+            // held in first person does not spam the reset/log every frame.
+            cam.orbit_move_armed = false;
+            const float stranded = player_onaction_reset();
+            if (stranded > k_orbit_move_input_stop)
+            {
+                DMK::Logger::get_instance().trace(
+                    "Orbit: TPV disengaged; cleared a stranded move-latch (magnitude {:.2f})", stranded);
+            }
+            s_orbit_was_engaged = false;
+        }
         cam.collision_valid = false;
         cam.collision_hold_timer = 0.0f;
         // First person (or suppressed): the camera is the eye, so the interaction hook must NOT redirect.
@@ -1661,6 +1724,7 @@ static void detour_frustum_build_impl(uintptr_t camera)
         Presets::reset_transition();
         return;
     }
+    s_orbit_was_engaged = true;
 
     // Resolve the active preset (by debounced state, or the overlay's editing pin) and ease the
     // live framing toward it BEFORE the matrix offset reads those settings this frame.
@@ -1792,20 +1856,29 @@ static void __fastcall detour_set_head_visibility(uintptr_t entity, bool hide_he
             return true; // block ONLY the look so the player look stays put while free-looking
         }
 
-        // Gamepad RIGHT STICK: latch the held DEFLECTION (-1..1); the render hook integrates it by rate
-        // (GamepadOrbitSpeed * delta_time). Blocking these is what stops the stick from ALSO turning
-        // the player while orbiting -- without capturing these ids, right-stick yaw still moves the camera WITH
-        // the player (it passes through) and vertical look is frozen (the orbit pitch-leveling overwrites it).
-        // Left stick (movement) keeps its own ids -> passes.
+        // Gamepad RIGHT STICK: latch the held DEFLECTION (-1..1) for the orbit rate integration, then ZERO
+        // the event value IN PLACE and let it PASS (do NOT block). A held analog stick drives an engine
+        // look-RATE that the engine only zeroes on a release event. BLOCKING swallows that release: if orbit
+        // engages while the stick is already deflected (e.g. you hold the right stick then toggle orbit, or an
+        // exclude state suspends/restores orbit mid-deflection), the engine keeps its last rate and SPINS the
+        // player look forever -- surviving a switch to first person and curable only by a hard input flush
+        // (menu / alt-tab). It is the same swallowed-release defect as the move latch, but stranding the
+        // ENGINE's own gamepad look. Zeroing the value instead means the engine continuously sees no
+        // deflection (so it never turns and never strands) while we keep the real value for the orbit camera;
+        // the release reaches the engine too. The mouse path above can still hard-block: a mouse delta is a
+        // one-shot nudge with no held rate, so there is nothing to strand. Left stick (movement) keeps its own
+        // ids and passes untouched.
         if (id == Constants::INPUT_PAD_LOOK_YAW_EVENT_ID)
         {
             cam.orbit_pad_yaw.store(value, std::memory_order_relaxed);
-            return true;
+            *reinterpret_cast<float *>(input_event + Constants::INPUT_EVENT_VALUE_OFFSET) = 0.0f;
+            return false;
         }
         if (id == Constants::INPUT_PAD_LOOK_PITCH_EVENT_ID)
         {
             cam.orbit_pad_pitch.store(value, std::memory_order_relaxed);
-            return true;
+            *reinterpret_cast<float *>(input_event + Constants::INPUT_EVENT_VALUE_OFFSET) = 0.0f;
+            return false;
         }
     }
 

--- a/TPVCamera/src/hooks/player_onaction_hook.cpp
+++ b/TPVCamera/src/hooks/player_onaction_hook.cpp
@@ -71,6 +71,24 @@ float player_onaction_move_magnitude()
     return magnitude;
 }
 
+float player_onaction_reset()
+{
+    // exchange() atomically reads-and-clears each slot, so a concurrent input-thread store of a fresh
+    // press is never lost (it simply re-latches after this returns). The largest cleared value is
+    // returned so the caller can tell whether the latch was genuinely stranded (> the stop threshold)
+    // versus already idle, which is the key signal in the log for the post-combat self-rotation bug.
+    float had = 0.0f;
+    for (size_t i = 0; i < k_move_count; ++i)
+    {
+        const float prev = s_move_values[i].exchange(0.0f, std::memory_order_relaxed);
+        if (prev > had)
+        {
+            had = prev;
+        }
+    }
+    return had;
+}
+
 /**
  * @brief Trace-only vocabulary probe: logs each distinct action name once so the on-foot movement-action
  *        names can be confirmed at runtime. Inert unless the trace log level is on; the dedup list

--- a/TPVCamera/src/hooks/player_onaction_hook.hpp
+++ b/TPVCamera/src/hooks/player_onaction_hook.hpp
@@ -39,6 +39,19 @@ namespace TPVCamera
  */
 [[nodiscard]] float player_onaction_move_magnitude();
 
+/**
+ * @brief Force-clears every latched movement magnitude to 0 and returns the largest value that was set.
+ * @details The latch is normally cleared only by a matching value==0 release event. On a combat action-map
+ *          swap (drawing a weapon, entering a minigame) that release can be SWALLOWED, stranding a slot > 0 so
+ *          the orbit move-detection re-trips with the keys released -- the camera then keeps turning the body
+ *          to a heading no input is driving (the post-combat self-rotation). Callers invoke this on the edges
+ *          where a strand can occur (orbit toggle-off, orbit-exclude entry, TPV disengage) to drop the stale
+ *          latch. The returned magnitude lets the caller log whether the latch WAS stranded (compare against
+ *          the move-stop threshold). Touches only the relaxed atomics, so it is safe from any thread.
+ * @return The largest magnitude that was latched at the moment of the reset (0 if all slots were clear).
+ */
+float player_onaction_reset();
+
 } // namespace TPVCamera
 
 #endif // TPVCAMERA_PLAYER_ONACTION_HOOK_HPP

--- a/TPVCamera/src/tpv_camera.cpp
+++ b/TPVCamera/src/tpv_camera.cpp
@@ -210,6 +210,15 @@ static void register_press_bindings()
                       cam.orbit_pitch.store(0.0f);
                   }
                   cam.orbit_active.store(new_state);
+                  if (!new_state)
+                  {
+                      // Disabling free-look clears no run-state on its own, so drop any stranded
+                      // movement-input latch here: otherwise a latch left > 0 (a release swallowed on a
+                      // combat action-map swap) re-trips the body-turn the next time orbit is enabled.
+                      const float stranded = player_onaction_reset();
+                      DMK::Logger::get_instance().trace("Orbit: toggled off; cleared move-latch (had magnitude {:.2f})",
+                                                        stranded);
+                  }
                   DMK::Logger::get_instance().info("Orbit camera {}", new_state ? "ENABLED" : "DISABLED");
               }, "F4,Gamepad_LB+Gamepad_LS");
 


### PR DESCRIPTION
## Summary

Fixes the free-look orbit camera (and character) spinning on its own and not stopping until you opened a menu or alt-tabbed.

**Cause:** the orbit input hook hard-blocked the gamepad right-stick look events. A held analog stick drives an engine look-rate that only stops on a release event; blocking swallowed that release, so toggling orbit with the stick deflected stranded the engine's look-rate, which spun forever and survived a switch to first person. Same swallowed-release defect class as the on-foot move latch.

**Fix:**
- Zero-pass the right-stick look events instead of blocking: latch the value for the orbit camera, then zero the event in place and let it pass, so the engine never sees a deflection to strand. Mouse look still hard-blocks (one-shot delta, no held rate).
- Clear the movement-input latch on orbit-off / exclude-enter / TPV-disengage edges, plus a move re-arm guard, to stop a stranded latch re-tripping the post-combat body-turn.
- Moved orbit free-look diagnostics to trace level.
