### PR TITLE
refactor(tpvcamera): resolve hooks via multi-candidate AOB cascades

### DIFF
--- a/TPVCamera/README.md
+++ b/TPVCamera/README.md
@@ -225,9 +225,15 @@ cmake --build --preset msvc-dev
 - `src/config.cpp`, `src/global_state.cpp`, `src/tpv_camera.cpp` - configuration, shared state,
   and the mod lifecycle
 
-Game addresses are located patch-resiliently: code via AOB pattern scanning, the `gEnv` global
-via a RIP-relative AOB (with a static fallback), and engine object types via their MSVC RTTI
-names rather than hardcoded vtable addresses.
+Game addresses are located patch-resiliently. Every hooked function and read global is found
+through a multi-candidate AOB cascade (`src/aob_resolver.hpp`): each target carries three ordered
+signatures, most-specific first, and the first that resolves wins, so a game patch only has to
+leave one anchor intact for the feature to keep working. At least one candidate per cascade
+anchors past the function prologue, so resolution still succeeds when another mod has inline-hooked
+the entry. The `gEnv` global resolves through the same cascade (with a static RVA fallback), and
+engine object types are matched by their MSVC RTTI names rather than hardcoded vtable addresses.
+The cascade signatures follow DetourModKit's
+[AOB signature guide](https://github.com/tkhquang/DetourModKit/blob/main/docs/misc/aob-signatures.md).
 
 ## Credits
 

--- a/TPVCamera/build/template/KCD2_TPVCamera.ini
+++ b/TPVCamera/build/template/KCD2_TPVCamera.ini
@@ -170,7 +170,7 @@ ForcedTPVState = Mount
 ; on when you leave (if it was on). Auto-disables on entry only, so you can
 ; still re-enable it by hand there. Combat and Mount are excluded because free-look
 ; currently fights the game's own camera control in those states. Live-editable.
-OrbitExcludeState = Menu,Overlay,Cart,Combat,Mount,Lockpicking,Dice,Reading,Alchemy,Pickpocketing,Blacksmithing,ForgeBuilder,Sharpening,HoleDigging,StoneThrowing,BattleArchery,Distract
+OrbitExcludeState = Menu,Overlay,Cart,Combat,Mount,Lockpicking,Dice,Reading,Alchemy,Pickpocketing,Blacksmithing,ForgeBuilder,Sharpening,StoneThrowing,BattleArchery,Distract
 
 ; StateSwitchHoldSeconds is how long a situation must last before the camera
 ; reacts (0 = instant), so a brief flicker does not pop the view. Live-editable.

--- a/TPVCamera/docs/NEXT_CHANGELOG.md
+++ b/TPVCamera/docs/NEXT_CHANGELOG.md
@@ -1,5 +1,5 @@
-## [Title for next release]
+## Fixes and Improvements
 
-- New feature
-- Bug fix
-- Improvement
+- Free-look orbit no longer turns off during the hole-digging minigame
+- The third-person camera no longer slips through fabric tent, awning, and stall roofs
+- Made the mod more likely to keep working after a game update

--- a/TPVCamera/docs/nexus-bbcode.txt
+++ b/TPVCamera/docs/nexus-bbcode.txt
@@ -1,41 +1,40 @@
-[size=6]Kingdom Come: Deliverance II - Third Person Camera[/size]
-
 [size=5]Foreword[/size]
-A while back I made [url=https://www.nexusmods.com/kingdomcomedeliverance2/mods/1550]KCD2_TPVToggle[/url], which switches on the game's built-in debug third-person camera. That camera was never meant for normal play, so working around its quirks and restrictions turned into a rabbit hole, and I ended up spending far more time fixing broken things than building anything new.
+A while back I made [url=https://www.nexusmods.com/kingdomcomedeliverance2/mods/1550]Third Person View (TPV Camera) Enabler[/url], which switches on the game's built-in debug third-person camera. That camera was never meant for normal play, so working around its quirks and restrictions turned into a rabbit hole, and I ended up spending far more time fixing broken things than building anything new.
 
 This mod is a complete rewrite from the opposite direction. Instead of borrowing the debug camera, it leaves the game in its normal first-person mode and rebuilds the third-person view on top of it, then adds the parts that actually matter: simple camera collision and raycast-based crosshair alignment. It is much simpler, and it genuinely works better. The funny part is that doing it this way came together in about two weeks, against the better part of a month I spent patching the old approach.
 
 It is still early days, so if anything feels off or you have an idea that would make it better, please let me know. I hope you enjoy it, and thank you for giving it a try.
 
-[size=5]Description[/size]
-A third-person camera mod for Kingdom Come: Deliverance II, with camera collision and frustum-culling correction, a partial raycast-based crosshair fix, and an experimental free-look orbit mode.
+[size=2]Note: Please forgive me for the bad video quality and framerate T_T[/size]
 
-Third-person turns on automatically once you reach gameplay; press the toggle key to switch back, or set AutoEnableTPV = false in the INI to start in first-person.
+[youtube]NuCQHDoQnVE[/youtube]
 
 [size=5]Key Features[/size]
 [list]
-[*] Third-person view you can toggle on and off at any time (default: F3, or hold LB + RB)
-[*] Over-the-shoulder framing with adjustable distance, height, and side offset
-[*] Zoom the camera in and out on the fly
-[*] Basic free-look orbit to look around your character (early, see Known Limitations)
-[*] Automatic view switching by situation: switch to first or third person when you enter combat, aiming a bow, dialogue, minigames, riding, or menus (you can still toggle manually during it), restoring your previous view when it ends
-[*] In-game preset manager: edit, add, and save camera presets from an overlay; built-in presets for normal play, combat, aiming, horseback, sneaking, and special poses (lying down, sitting, kneeling, riding a cart) apply automatically by situation, and you can bind your own presets to combinations of states (such as aiming while crouched), with the most specific match winning
-[*] Camera collision that pulls the view in so it does not clip through walls
-[*] Crosshair stays lined up with what you point at
-[*] Full keyboard and XInput controller support
-[*] Almost every setting is editable live while the game runs
-[*] [url=https://github.com/tkhquang/KCD2Tools]Open-source[/url] with full transparency
+[*]Third-person view you can toggle on and off at any time (default: F3, or hold LB + RB)[/*]
+[*]Over-the-shoulder framing with adjustable distance, height, and side offset[/*]
+[*]Zoom the camera in and out on the fly[/*]
+[*]Basic free-look orbit to look around your character (early, see Known Limitations)[/*]
+[*]Automatic view switching by situation: switch to first or third person when you enter combat, aiming a bow, dialogue, minigames, riding, or menus (you can still toggle manually during it), restoring your previous view when it ends[/*]
+[*]In-game preset manager: edit, add, and save camera presets from an overlay; built-in presets for normal play, combat, aiming, horseback, sneaking, and special poses (lying down, sitting, kneeling, riding a cart) apply automatically by situation, and you can bind your own presets to combinations of states (such as aiming while crouched), with the most specific match winning[/*]
+[*]Camera collision that pulls the view in so it does not clip through walls[/*]
+[*]Crosshair stays lined up with what you point at (partly, only for interactions and not 100% yet)[/*]
+[*]Full keyboard and XInput controller support[/*]
+[*]Almost every setting is editable live while the game runs[/*]
+[*][url=https://github.com/tkhquang/KCD2Tools]Open-source[/url] with full transparency[/*]
 [/list]
+Third-person turns on automatically once you reach gameplay; press the toggle key to switch back, or set AutoEnableTPV = false in the INI to start in first-person.
 
 [size=5]Requirements[/size]
 [list]
-[*] Kingdom Come: Deliverance II (Steam version)
+[*]Kingdom Come: Deliverance II (Steam version)[/*]
 [/list]
 
 [size=5]Installation[/size]
 1. If you have the older [url=https://www.nexusmods.com/kingdomcomedeliverance2/mods/1550]KCD2_TPVToggle[/url] mod installed, remove it first: delete KCD2_TPVToggle.asi and KCD2_TPVToggle.ini from your game directory. TPVCamera replaces it, and running both third-person camera mods at once will conflict.
 2. Extract all files from the archive to your game directory:
-  [code]<KC:D 2 installation folder>/Bin/Win64MasterMasterSteamPGO/[/code]
+ 
+[code]<KC:D 2 installation folder>/Bin/Win64MasterMasterSteamPGO/[/code]
 3. Launch the game; third-person turns on automatically. Press F3 (or hold LB + RB) to toggle back to first-person
 
 [size=5]Linux / Steam Deck (Wine/Proton)[/size]
@@ -50,70 +49,84 @@ Since this mod uses dinput8.dll as the ASI loader, you need to tell Wine/Proton 
 [size=5]Default Controls[/size]
 All keys are rebindable in KCD2_TPVCamera.ini.
 [list]
-[*] [b]Enter / exit third-person:[/b] F3, or hold LB + RB
-[*] [b]Toggle free-look orbit:[/b] F4, or hold LB + click the left stick (LS)
-[*] [b]Open preset manager overlay:[/b] Home
-[*] [b]Zoom in:[/b] LShift + PageUp, or hold LB + D-pad up
-[*] [b]Zoom out:[/b] LShift + PageDown, or hold LB + D-pad down
-[*] [b]Force first-person / force third-person:[/b] unbound by default
+[*][b]Enter / exit third-person:[/b] F3, or hold LB + RB[/*]
+[*][b]Toggle free-look orbit:[/b] F4, or hold LB + click the left stick (LS)[/*]
+[*][b]Open preset manager overlay:[/b] Home[/*]
+[*][b]Zoom in:[/b] LShift + PageUp, or hold LB + D-pad up[/*]
+[*][b]Zoom out:[/b] LShift + PageDown, or hold LB + D-pad down[/*]
+[*][b]Force first-person / force third-person:[/b] unbound by default[/*]
 [/list]
 
 [size=5]Configuration[/size]
 Edit KCD2_TPVCamera.ini, grouped into:
 [list]
-[*] [b][Settings][/b] - log level, the view hotkeys, the preset-overlay key, and the start-of-session auto-enable flags
-[*] [b][Camera][/b] - zoom keys, the camera-space interaction toggle, and the view-transition ease (the framing itself is per-preset)
-[*] [b][Orbit][/b] - the free-look orbit key and the cursor freeze (the orbit feel is per-preset)
-[*] [b][Collision][/b] - the sphere-vs-ray collision probe and its radius (enable, skin, and return speed are per-preset)
-[*] [b][StateBehavior][/b] - switch first/third person on entering a situation (combat, aiming, dialogue, minigame, mount, menu, overlay), restore the prior view on exit (manual toggles during it stick), and suspend/restore free-look in chosen situations
-[*] [b][Presets][/b] - the preset blend speed; the camera framing lives in the in-game preset manager (open with Home) and is stored in KCD2_TPVCamera_presets.json next to the INI. That file is created automatically from the built-in defaults on first run; it is not shipped, so updating the mod never overwrites presets you have tuned
+[*][b][Settings][/b] - log level, the view hotkeys, the preset-overlay key, and the start-of-session auto-enable flags[/*]
+[*][b][Camera][/b] - zoom keys, the camera-space interaction toggle, and the view-transition ease (the framing itself is per-preset)[/*]
+[*][b][Orbit][/b] - the free-look orbit key and the cursor freeze (the orbit feel is per-preset)[/*]
+[*][b][Collision][/b] - the sphere-vs-ray collision probe and its radius (enable, skin, and return speed are per-preset)[/*]
+[*][b][StateBehavior][/b] - switch first/third person on entering a situation (combat, aiming, dialogue, minigame, mount, menu, overlay), restore the prior view on exit (manual toggles during it stick), and suspend/restore free-look in chosen situations[/*]
+[*][b][Presets][/b] - the preset blend speed; the camera framing lives in the in-game preset manager (open with Home) and is stored in KCD2_TPVCamera_presets.json next to the INI. That file is created automatically from the built-in defaults on first run; it is not shipped, so updating the mod never overwrites presets you have tuned[/*]
 [/list]
 Most values apply the next frame after you save the file.
 
 [size=5]Using with Controllers[/size]
-DetourModKit supports gamepad input natively via the XInput API. You can use gamepad button names directly in the INI, for example:
+[url=https://github.com/tkhquang/DetourModKit#supported-input-names]DetourModKit [/url]supports gamepad input natively via the XInput API. You can use gamepad button names directly in the INI, for example:
 [code]ToggleViewKey = F3,Gamepad_LB+Gamepad_RB[/code]
 Xbox controllers work natively. For PS4/PS5/Switch controllers, use DS4Windows, Steam Input, or a similar tool to present your controller as XInput.
+
+[size=4]Hotkey Format[/size]
+[list]
+[*]Named keys: [b]T[/b], [b]F3[/b], [b]Numpad1[/b], [b]Mouse4[/b], [b]Gamepad_A[/b], etc.[/*]
+[*]Modifiers: [b]Ctrl[/b], [b]Shift[/b], [b]Alt[/b] (or LCtrl, RCtrl, etc.)[/*]
+[*]Multiple combos: [b]T,Gamepad_LB+Gamepad_Y[/b] (T alone OR hold LB + press Y)[/*]
+[*]Empty value = disabled[/*]
+[/list]
+
+See the full list at the [url=https://github.com/tkhquang/DetourModKit?tab=readme-ov-file#supported-input-names]Supported Input Names[/url] reference.
 
 [size=5]Recommended Mods[/size]
 These pair well with a third-person camera:
 [list]
-[*] [url=https://www.nexusmods.com/kingdomcomedeliverance2/mods/93]No Helmet Vision[/url] - removes the helmet vision letterbox/black bars that look out of place in third-person.
-[*] [url=https://www.nexusmods.com/kingdomcomedeliverance2/mods/269]First Person Overhaul[/url] - keeps certain scripted actions and interactions in third person instead of forcing the view back to first person.
-[*] [url=https://www.nexusmods.com/kingdomcomedeliverance2/mods/2497]Alternate Combat[/url] (optional) - modifies combat and camera lock-on behaviour to make melee combat more free and target switching easier.
+[*][url=https://www.nexusmods.com/kingdomcomedeliverance2/mods/93]No Helmet Vision[/url] - removes the helmet vision letterbox/black bars that look out of place in third-person.[/*]
+[*][url=https://www.nexusmods.com/kingdomcomedeliverance2/mods/269]First Person Overhaul[/url] - keeps certain actions and interactions in third person instead of forcing the view back to game default camera.[/*]
+[*][url=https://www.nexusmods.com/kingdomcomedeliverance2/mods/2497]Alternate Combat[/url] (optional) - modifies combat and camera lock-on behaviour to make melee combat more free and target switching easier.[/*]
 [/list]
 
 [size=5]Known Limitations[/size]
 [list]
-[*] Free-look orbit is a raw proof-of-concept: fine for swinging the camera around to look at the front of Henry, but rough for normal gameplay (interaction while orbiting does not work yet).
-[*] Free-look orbit conflicts with the game's own camera control on horseback and in combat, so it is auto-disabled in those situations.
-[*] The first-person body rig can still look slightly off from behind in some animations.
-[*] Camera collision keeps the view out of walls but has no soft-edge smoothing yet.
-[*] The raycast-based crosshair fix is partial: it does not cover every interaction type, so some still show parallax or an offset, and in a dense area with several interactables the use-prompt can jump back and forth.
-[*] Certain world interactions in third person can still be janky or buggy; toggle the camera off if one looks wrong.
-[*] The preset overlay does not hook the game's swap chain by design: it renders through a private WARP device and composites with a GDI blit, which keeps it compatible with overlays and injectors like ReShade and OptiScaler. The trade-off is a frame-rate hit while the overlay is open; since it is a tuning panel you open briefly rather than play with, that is acceptable.
+[*]Free-look orbit is a raw proof-of-concept: fine for swinging the camera around to look at the front of Henry, but rough for normal gameplay (interaction while orbiting does not work yet).[/*]
+[*]Free-look orbit conflicts with the game's own camera control on horseback and in combat, so it is auto-disabled in those situations.[/*]
+[*]The first-person body rig can still look slightly off from behind in some animations.[/*]
+[*]Camera collision keeps the view out of walls but has no soft-edge smoothing yet.[/*]
+[*]The raycast-based crosshair fix is partial: it does not cover every interaction type, so some still show parallax or an offset, and in a dense area with several interactables the use-prompt can jump back and forth.[/*]
+[*]Certain world interactions in third person can still be janky or buggy; toggle the camera off if one looks wrong.[/*]
+[*]The preset overlay does not hook the game's swap chain by design: it renders through a private WARP device and composites with a GDI blit, which keeps it compatible with overlays and injectors like ReShade and OptiScaler. The trade-off is a frame-rate hit while the overlay is open; since it is a tuning panel you open briefly rather than play with, that is acceptable.[/*]
 [/list]
 
 [size=5]Roadmap[/size]
 [list]
-[*] Rework the free-look orbit so it is usable in normal gameplay (interaction during orbit, smoother engage/release, better mouse feel), including resolving the conflict with the game's own camera on horseback and in combat where orbit is currently auto-disabled.
-[*] Soft-edge camera collision so the view eases around obstacles instead of snapping.
-[*] Handle thin occluders (fence rails, thin foliage) between the camera and the character more cleanly.
-[*] Fix shadows being cut off behind the character (the shadow cascade still follows the first-person eye).
-[*] Extend the raycast-based crosshair/interaction fix to cover more interaction types and stop the use-prompt jumping between nearby interactables in dense areas.
+[*]Rework the free-look orbit so it is usable in normal gameplay (interaction during orbit, smoother engage/release, better mouse feel), including resolving the conflict with the game's own camera on horseback and in combat where orbit is currently auto-disabled.[/*]
+[*]Soft-edge camera collision so the view eases around obstacles instead of snapping.[/*]
+[*]Handle thin occluders (fence rails, thin foliage) between the camera and the character more cleanly.[/*]
+[*]Fix shadows being cut off behind the character (the shadow cascade still follows the first-person eye).[/*]
+[*]Extend the raycast-based crosshair/interaction fix to cover more interaction types and stop the use-prompt jumping between nearby interactables in dense areas.[/*]
 [/list]
 
-[b]After a game update:[/b] The AOB (Array-of-Bytes) pattern scanning automatically adapts to minor game changes, but major updates may require a mod update if core game functions have been modified.
+[b]After a game update:[/b] The mod locates each game function it hooks through several fallback signatures, so it automatically adapts to minor game changes. Major updates may still require a mod update if core game functions have been heavily rewritten.
 
 [size=5]Credits & Source Code[/size]
 Built with [url=https://github.com/tkhquang/DetourModKit]DetourModKit[/url] for core functionality.
 
 [list]
-[*] [url=https://github.com/ThirteenAG]ThirteenAG[/url] for the Ultimate ASI Loader
-[*] [url=https://github.com/cursey]cursey[/url] for SafetyHook
-[*] Brodie Thiesfield for SimpleIni
-[*] Frans 'Otis_Inf' Bouma for his camera tools and inspiration
-[*] Warhorse Studios for creating this amazing game
+[*][url=https://github.com/ThirteenAG/Ultimate-ASI-Loader]Ultimate ASI Loader[/url] by ThirteenAG - ASI loading layer[/*]
+[*][url=https://github.com/cursey/safetyhook]SafetyHook[/url] by cursey - inline / mid-function hooking[/*]
+[*][url=https://github.com/zyantific/zydis]Zydis[/url] / [url=https://github.com/zyantific/zycore-c]Zycore[/url] by Florian Bernd & Joel Höner - x86/x64 disassembly (used by SafetyHook)[/*]
+[*][url=https://github.com/brofield/simpleini]SimpleIni[/url] by Brodie Thiesfield - INI configuration parser[/*]
+[*][url=https://github.com/nlohmann/json]nlohmann/json[/url] by Niels Lohmann - JSON preset serialization[/*]
+[*][url=https://github.com/ocornut/imgui]Dear ImGui[/url] by Omar Cornut - overlay GUI[/*]
+[*][url=https://github.com/microsoft/DirectXMath]DirectXMath[/url] by Microsoft - math primitives[/*]
+[*][url=https://github.com/FransBouma]Frans 'Otis_Inf' Bouma[/url] - for his camera tools and inspiration, plus modding direction and guidance[/*]
+[*]Warhorse Studios for creating this amazing game[/*]
 [/list]
 
 All my Kingdom Come: Deliverance II mods and tools can be found in this [url=https://github.com/tkhquang/KCD2Tools]GitHub repository[/url]. Feel free to contribute or suggest improvements!

--- a/TPVCamera/src/aob_resolver.hpp
+++ b/TPVCamera/src/aob_resolver.hpp
@@ -1,0 +1,361 @@
+/**
+ * @file aob_resolver.hpp
+ * @brief Cascading AOB candidate tables and the resolve helper for the mod.
+ *
+ * Every memory location the mod hooks or reads is located by a cascade of
+ * ordered AOB candidates rather than a single signature, so a game patch that
+ * shifts code only has to leave ONE of three anchors intact for the feature to
+ * keep working. Resolution is delegated to DetourModKit's cascading scanner
+ * (DMK::Scanner::resolve_cascade); resolve_address() flattens its
+ * std::expected return into the uintptr_t-or-zero shape the call sites use.
+ *
+ * Candidate ordering is most-specific first (P1), so a tight anchor wins before
+ * a looser fallback. Each cascade carries at least one candidate anchored PAST
+ * the 5-byte function prologue (a negative disp_offset that walks back to the
+ * entry); that mid-body anchor still matches when a sibling mod has inline-hooked
+ * the entry, because it never reads the overwritten bytes. For that reason, and
+ * because these targets may be reshaped by a future game patch (not merely
+ * inline-hooked), the resolver uses the STRICT resolve_cascade and NOT the
+ * prologue-rewrite fallback: a full miss is a clean failure, never a guess at an
+ * unrelated near-JMP site (see external DMK docs/misc/aob-signatures.md section 6.4).
+ *
+ * Resolution shapes (DMK::Scanner::ResolveMode):
+ *   - Direct      address = match + disp_offset. Entry-hook targets resolve to the
+ *                 function entry (disp_offset 0); mid-body anchors use a negative
+ *                 disp_offset equal to the entry->anchor byte distance.
+ *   - RipRelative address = match + instr_end_offset + int32(match + disp_offset).
+ *                 Resolves a lea/mov [rip+disp32] to the data slot it references
+ *                 (the global-context storage slot and the g_env base).
+ *
+ * Every candidate below was verified to return exactly one match against the
+ * live retail WHGame.dll; the per-cascade comments and the RVAs are recorded in
+ * docs/analysis/aob_cascade_resolution.md.
+ */
+#ifndef TPVCAMERA_AOB_RESOLVER_HPP
+#define TPVCAMERA_AOB_RESOLVER_HPP
+
+#include <DetourModKit.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <span>
+#include <string_view>
+
+namespace TPVCamera
+{
+    using AddrCandidate = DMK::Scanner::AddrCandidate;
+    using ResolveMode = DMK::Scanner::ResolveMode;
+
+    namespace detail
+    {
+        /**
+         * @brief Resolve the first matching candidate of a cascade to an absolute
+         *        address, or 0 on total failure.
+         * @details The cascade already logs the winning candidate on success; on
+         *          failure this emits a single Warning so call sites can stay
+         *          focused on conditional feature wiring. Uses the strict
+         *          resolve_cascade (no prologue-rewrite fallback) so a full miss
+         *          is reported as a hard failure rather than a guess at an
+         *          unrelated near-JMP. Resolution still works through a
+         *          sibling-hooked prologue via the mid-body candidates each
+         *          cascade carries.
+         */
+        [[nodiscard]] inline std::uintptr_t resolve_cascade_or_zero(
+            std::span<const AddrCandidate> candidates, std::string_view label)
+        {
+            const auto hit = DMK::Scanner::resolve_cascade(candidates, label);
+            if (hit.has_value())
+            {
+                return hit->address;
+            }
+
+            DMK::Logger::get_instance().warning(
+                "{} resolve cascade failed: {}", label,
+                DMK::Scanner::resolve_error_to_string(hit.error()));
+            return 0;
+        }
+    } // namespace detail
+
+    /**
+     * @brief Resolve a candidate cascade to an absolute address, or 0 on failure.
+     */
+    template <std::size_t N>
+    [[nodiscard]] inline std::uintptr_t resolve_address(
+        const AddrCandidate (&candidates)[N], std::string_view label)
+    {
+        return detail::resolve_cascade_or_zero(
+            std::span<const AddrCandidate>{candidates, N}, label);
+    }
+
+    namespace Aob
+    {
+        // --- Global-context storage slot (qword_18549B4B0) -------------------
+        // RipRelative: all three candidates resolve the SAME data slot the
+        // camera-manager walk reads (context + OFFSET_MANAGER_PTR_STORAGE). P1
+        // anchors in the TLS-guarded accessor (sub_18091C138) on the `jg` that
+        // skips the fast-path epilogue; the mov it precedes loads the slot. The
+        // accessor's body is a generic magic-static guard shared by dozens of
+        // sibling accessors, so P2/P3 instead anchor on two OTHER functions that
+        // load the slot, each isolated by a distinctive neighbouring field test
+        // (cmp qword [rax+0E0h] / mov [rax+0F8h]). Three independent code sites
+        // means a patch must move all three before the slot is lost.
+        inline constexpr AddrCandidate k_contextCandidates[] = {
+            {"Context_P1_GuardJgFastPathMov",
+             "7F ?? 48 8B 05 ?? ?? ?? ?? 48 83 C4 ?? 5B C3",
+             ResolveMode::RipRelative, 5, 9},
+            {"Context_P2_LoadCheckFieldE0",
+             "48 8B 05 ?? ?? ?? ?? 48 83 B8 E0 00 00 00 00 74 ?? 42 8B 04 33 39 05",
+             ResolveMode::RipRelative, 3, 7},
+            {"Context_P3_LoadFieldF8Jnz",
+             "48 8B 05 ?? ?? ?? ?? 48 8B A8 F8 00 00 00 75 ?? E8",
+             ResolveMode::RipRelative, 3, 7},
+        };
+
+        // --- SSystemGlobalEnvironment base (g_env, 0x18492B800) --------------
+        // RipRelative: all three resolve the g_env base. P1/P3 anchor on the same
+        // `GetIGameFramework` call site (sub_181DCAF60): P1 leads with the
+        // `mov r8, rdi` that precedes the lea, P3 drops it and anchors on the lea
+        // plus the trailing virtual-call chain. P2 is a genuinely different site
+        // (a struct-init sequence storing the g_env pointer into a member),
+        // giving two independent reference sites. A static-RVA fallback in
+        // camera_hook covers a total miss, so a third fully-distinct anchor is
+        // not required here.
+        inline constexpr AddrCandidate k_genvCandidates[] = {
+            {"Genv_P1_LeaR8FrameworkChain",
+             "4C 8B C7 48 8D 15 ?? ?? ?? ?? 48 8B CB E8 ?? ?? ?? ?? 48 8B 0D ?? ?? ?? ?? 48 8B D3 48 8B 01 FF 50 18",
+             ResolveMode::RipRelative, 6, 10},
+            {"Genv_P2_LeaStructInit",
+             "48 8D 05 ?? ?? ?? ?? 48 89 0F 4C 8D 67 28 48 8D 0D ?? ?? ?? ?? 48 89 47 20 48 89 4F 08",
+             ResolveMode::RipRelative, 3, 7},
+            {"Genv_P3_LeaFrameworkChainTail",
+             "48 8D 15 ?? ?? ?? ?? 48 8B CB E8 ?? ?? ?? ?? 48 8B 0D ?? ?? ?? ?? 48 8B D3 48 8B 01 FF 50 18",
+             ResolveMode::RipRelative, 3, 7},
+        };
+
+        // --- Camera frustum builder (CCamera::UpdateFrustumPlanes) entry -----
+        // Direct entry hook. P1 is the full prologue (mov rax,rsp + 9 pushes +
+        // lea + sub) into the first matrix read. P2 drops the `mov rax,rsp` lead
+        // and walks back 3 bytes. P3 anchors purely on the body's distinctive
+        // matrix-read run (the movss [rcx+disp] chain that reads the 3x4 camera
+        // matrix) and walks back 0x1A. The lea displacement and sub-rsp immediate
+        // are wildcarded for frame-size resilience.
+        inline constexpr AddrCandidate k_frustumCandidates[] = {
+            {"Frustum_P1_PrologueMatrixRead",
+             "48 8B C4 55 53 56 57 41 54 41 55 41 56 41 57 48 8D 68 ?? 48 81 EC ?? ?? 00 00 F3 0F 10 09 48 8B D9",
+             ResolveMode::Direct, 0, 0},
+            {"Frustum_P2_PushChainMatrixRead",
+             "55 53 56 57 41 54 41 55 41 56 41 57 48 8D 68 ?? 48 81 EC ?? ?? 00 00 F3 0F 10 09 48 8B D9 F3 0F 10 59 08",
+             ResolveMode::Direct, -3, 0},
+            {"Frustum_P3_MatrixReadBody",
+             "F3 0F 10 09 48 8B D9 F3 0F 10 59 08 F3 0F 10 51 10 F3 0F 10 41 24 F3 0F 10 61 28",
+             ResolveMode::Direct, -0x1A, 0},
+        };
+
+        // --- Head-visibility setter entry -----------------------------------
+        // Direct entry hook (this, bool hide_head /*dl*/, char flags /*r8b*/).
+        // P1 is the current prologue through `mov sil, r8b`. P2 extends through
+        // the `mov dil,dl; mov rbx,rcx; call; test al,al` body for extra pinning.
+        // P3 drops the two stack-save stores and walks back 0x0A from the push.
+        inline constexpr AddrCandidate k_headVisibilityCandidates[] = {
+            {"Head_P1_PrologueMovSil",
+             "48 89 5C 24 10 48 89 74 24 18 57 48 83 EC ?? 41 8A F0",
+             ResolveMode::Direct, 0, 0},
+            {"Head_P2_PrologueMovSilCall",
+             "48 89 5C 24 10 48 89 74 24 18 57 48 83 EC ?? 41 8A F0 40 8A FA 48 8B D9 E8 ?? ?? ?? ?? 84 C0",
+             ResolveMode::Direct, 0, 0},
+            {"Head_P3_BodyMovSilDilRbx",
+             "57 48 83 EC ?? 41 8A F0 40 8A FA 48 8B D9 E8 ?? ?? ?? ?? 84 C0 74",
+             ResolveMode::Direct, -0x0A, 0},
+        };
+
+        // --- Generic input-event dispatcher entry ---------------------------
+        // Direct entry hook. The `cmp [rcx+0D8h], r8b` guard is the unique
+        // landmark; the jnz rel8 that skips it is wildcarded. P2 extends past the
+        // first jz rel32 into the `cmp [rdx+10h], -1` pitch check. P3 drops the
+        // two prologue stores and walks back 0x0A.
+        inline constexpr AddrCandidate k_inputDispatchCandidates[] = {
+            {"Input_P1_PrologueGuardCmp",
+             "48 89 5C 24 08 57 48 83 EC ?? 48 8B DA 48 8B F9 45 84 C0 75 ?? 44 38 81 D8 00 00 00 0F 84",
+             ResolveMode::Direct, 0, 0},
+            {"Input_P2_GuardThroughPitchCmp",
+             "48 89 5C 24 08 57 48 83 EC ?? 48 8B DA 48 8B F9 45 84 C0 75 ?? 44 38 81 D8 00 00 00 0F 84 ?? ?? ?? ?? 83 7A 10 FF 0F 84",
+             ResolveMode::Direct, 0, 0},
+            {"Input_P3_BodyGuardCmpPitch",
+             "48 8B DA 48 8B F9 45 84 C0 75 ?? 44 38 81 D8 00 00 00 0F 84 ?? ?? ?? ?? 83 7A 10 FF",
+             ResolveMode::Direct, -0x0A, 0},
+        };
+
+        // --- Global action dispatcher entry (Lua Player:OnAction source) -----
+        // Direct entry hook. The `movss [rax+20h], xmm3` that stores the float
+        // value arg is the distinctive head. P2 extends past the sub-rsp into the
+        // first movaps + `mov rdi,rcx`. P3 anchors on the movss-store body and
+        // walks back 0x0B. Frame displacement and stack size are wildcarded.
+        inline constexpr AddrCandidate k_actionDispatchCandidates[] = {
+            {"Action_P1_PrologueMovssVal",
+             "48 8B C4 48 89 58 10 48 89 70 18 F3 0F 11 58 20 55 57 41 56 48 8D 68 ?? 48 81 EC ?? ?? ?? ??",
+             ResolveMode::Direct, 0, 0},
+            {"Action_P2_PrologueThroughMovaps",
+             "48 8B C4 48 89 58 10 48 89 70 18 F3 0F 11 58 20 55 57 41 56 48 8D 68 ?? 48 81 EC ?? ?? ?? ?? 0F 29 70 ?? 48 8B F9",
+             ResolveMode::Direct, 0, 0},
+            {"Action_P3_MovssValBody",
+             "F3 0F 11 58 20 55 57 41 56 48 8D 68 ?? 48 81 EC ?? ?? ?? ?? 0F 29 70 ?? 48 8B F9 8B 41 18 41 BE 01 00 00 00",
+             ResolveMode::Direct, -0x0B, 0},
+        };
+
+        // --- IPhysicalWorld::RayWorldIntersection helper entry ---------------
+        // Direct: the match IS the callable function pointer (no detour). A
+        // sibling helper (sub_1838D6E3C) shares the prologue and the first inner
+        // call, then diverges: this helper stages the next call's count with
+        // `mov r9d, imm32` (41 B9) where the sibling does `mov rcx, r9`. EVERY
+        // candidate therefore extends to the 41 B9 discriminator so none can
+        // resolve onto the sibling. P2 drops the `mov rax,rsp` lead (walk back 3);
+        // P3 anchors on the arg-staging body (walk back 0x1F).
+        inline constexpr AddrCandidate k_rayWorldIntersectionCandidates[] = {
+            {"Ray_P1_PrologueThroughR9dImm",
+             "48 8B C4 48 89 58 08 48 89 70 10 48 89 78 18 4C 89 70 20 55 48 8D 68 ?? 48 81 EC ?? ?? 00 00 "
+             "48 8B DA 49 8B F8 33 D2 4C 8B F1 48 8D 4D ?? 41 8B F1 44 8D 42 70 E8 ?? ?? ?? ?? 8B 43 08 "
+             "48 8D 55 ?? F2 0F 10 03 41 B9 ?? ?? ?? ??",
+             ResolveMode::Direct, 0, 0},
+            {"Ray_P2_SavesThroughR9dImm",
+             "48 89 58 08 48 89 70 10 48 89 78 18 4C 89 70 20 55 48 8D 68 ?? 48 81 EC ?? ?? 00 00 "
+             "48 8B DA 49 8B F8 33 D2 4C 8B F1 48 8D 4D ?? 41 8B F1 44 8D 42 70 E8 ?? ?? ?? ?? 8B 43 08 "
+             "48 8D 55 ?? F2 0F 10 03 41 B9",
+             ResolveMode::Direct, -3, 0},
+            {"Ray_P3_BodyThroughR9dImm",
+             "48 8B DA 49 8B F8 33 D2 4C 8B F1 48 8D 4D ?? 41 8B F1 44 8D 42 70 E8 ?? ?? ?? ?? 8B 43 08 "
+             "48 8D 55 ?? F2 0F 10 03 41 B9",
+             ResolveMode::Direct, -0x1F, 0},
+        };
+
+        // --- Interaction ray-query builder entry ----------------------------
+        // Direct entry hook. The function is a leaf-style Vec3 copier with no
+        // standard prologue, so all anchors are body-shaped. P2 extends the
+        // vec-copy run; P3 anchors on the distinctive `mov [rcx+228h], al` store
+        // and walks back 0x1B.
+        inline constexpr AddrCandidate k_interactionRayBuildCandidates[] = {
+            {"RayBuild_P1_VecCopyHead",
+             "F2 0F 10 02 4C 8B D1 4C 8B 5C 24 30 F2 0F 11 01 8B 42 08 89 41 08 F2 41 0F 10 00",
+             ResolveMode::Direct, 0, 0},
+            {"RayBuild_P2_VecCopyExtended",
+             "F2 0F 10 02 4C 8B D1 4C 8B 5C 24 30 F2 0F 11 01 8B 42 08 89 41 08 F2 41 0F 10 00 "
+             "F2 0F 11 41 0C 41 8B 40 08 89 41 14",
+             ResolveMode::Direct, 0, 0},
+            {"RayBuild_P3_Store228Body",
+             "F2 0F 11 41 0C 41 8B 40 08 89 41 14 8B 44 24 28 89 41 1C 8A 44 24 40 88 81 28 02 00 00",
+             ResolveMode::Direct, -0x1B, 0},
+        };
+
+        // --- Interactor look-ray builder entry (used as a caller-range bound) -
+        // Direct: resolves the function entry; the caller range [entry, entry +
+        // INTERACTOR_LOOKRAY_SPAN) gates the ray-build detour. The xmm-save
+        // prologue is shared by many functions, so P2/P3 extend past the saves
+        // into the stack-canary load (`mov rax,[rip+cookie]; xor rax,rsp`) to
+        // stay unique. P2 walks back 0x0B, P3 walks back 0x21.
+        inline constexpr AddrCandidate k_interactorLookRayCandidates[] = {
+            {"LookRay_P1_PrologueXmmSaves",
+             "48 8B C4 48 89 58 10 48 89 70 18 55 57 41 54 41 56 41 57 48 8D A8 ?? ?? FF FF 48 81 EC ?? ?? 00 00 "
+             "0F 29 70 C8 0F 29 78 B8 44 0F 29 40 A8 44 0F 29 50 98 44 0F 29 58 88",
+             ResolveMode::Direct, 0, 0},
+            {"LookRay_P2_PushXmmCanary",
+             "55 57 41 54 41 56 41 57 48 8D A8 ?? ?? FF FF 48 81 EC ?? ?? 00 00 "
+             "0F 29 70 C8 0F 29 78 B8 44 0F 29 40 A8 44 0F 29 50 98 44 0F 29 58 88 48 8B 05 ?? ?? ?? ?? 48 33 C4",
+             ResolveMode::Direct, -0x0B, 0},
+            {"LookRay_P3_XmmCanaryBody",
+             "0F 29 70 C8 0F 29 78 B8 44 0F 29 40 A8 44 0F 29 50 98 44 0F 29 58 88 "
+             "48 8B 05 ?? ?? ?? ?? 48 33 C4 48 89 85 ?? ?? ?? ?? 4C 8B F9",
+             ResolveMode::Direct, -0x21, 0},
+        };
+
+        // --- On-screen reticle projection gate entry ------------------------
+        // Direct entry hook. P1 is the prologue through `mov rcx, [rip+cam]`. P2
+        // extends through the first two movss reads of the candidate world point.
+        // P3 drops the leading shadow-save and walks back 0x0B.
+        inline constexpr AddrCandidate k_interactionOnScreenCandidates[] = {
+            {"OnScreen_P1_PrologueMovGlobal",
+             "4C 8B DC 49 89 5B 10 49 89 73 18 49 89 4B 08 57 48 83 EC ?? 48 8B 0D ?? ?? ?? ?? 49 8D 70 04",
+             ResolveMode::Direct, 0, 0},
+            {"OnScreen_P2_PrologueThroughMovss",
+             "4C 8B DC 49 89 5B 10 49 89 73 18 49 89 4B 08 57 48 83 EC ?? 48 8B 0D ?? ?? ?? ?? 49 8D 70 04 "
+             "F3 0F 10 5A 08 49 8B F8 F3 0F 10 52 04",
+             ResolveMode::Direct, 0, 0},
+            {"OnScreen_P3_BodyMovGlobalMovss",
+             "49 89 4B 08 57 48 83 EC ?? 48 8B 0D ?? ?? ?? ?? 49 8D 70 04 "
+             "F3 0F 10 5A 08 49 8B F8 F3 0F 10 52 04 4D 8D 43 08 F3 0F 10 0A",
+             ResolveMode::Direct, -0x0B, 0},
+        };
+
+        // --- HideOverlays entry ---------------------------------------------
+        // Direct entry hook. HideOverlays and ShowOverlays share the prologue, so
+        // every candidate keeps the `mov byte [rax+rcx+0B8h], 1` set-flag store
+        // (C6 84 ?? ?? ?? ?? ?? 01) that distinguishes Hide from Show's cmp. P3
+        // drops the prologue and walks back 0x0A.
+        inline constexpr AddrCandidate k_overlayHideCandidates[] = {
+            {"OverlayHide_P1_PrologueSetFlag",
+             "44 88 44 24 18 53 48 83 EC ?? 0F B6 C2 48 8B D9 48 8D 15 ?? ?? ?? ?? C6 84 ?? ?? ?? ?? ?? 01",
+             ResolveMode::Direct, 0, 0},
+            {"OverlayHide_P2_SetFlagThroughCall",
+             "44 88 44 24 18 53 48 83 EC ?? 0F B6 C2 48 8B D9 48 8D 15 ?? ?? ?? ?? C6 84 ?? ?? ?? ?? ?? 01 48 8D 4C 24 ?? E8",
+             ResolveMode::Direct, 0, 0},
+            {"OverlayHide_P3_BodySetFlag",
+             "0F B6 C2 48 8B D9 48 8D 15 ?? ?? ?? ?? C6 84 ?? ?? ?? ?? ?? 01 48 8D 4C 24 ?? E8",
+             ResolveMode::Direct, -0x0A, 0},
+        };
+
+        // --- ShowOverlays entry ---------------------------------------------
+        // Direct entry hook. The `cmp byte [rax+rcx+0B8h], 0` test-flag read
+        // (80 BC ?? ?? ?? ?? ?? 00) is the discriminator versus Hide's store. P1
+        // deliberately stops before the following jz rel8 (the encoding can flip).
+        // P2 wildcards that jz as ?? ?? and extends into the flag-clear store and
+        // call. P3 drops the prologue and walks back 0x0A.
+        inline constexpr AddrCandidate k_overlayShowCandidates[] = {
+            {"OverlayShow_P1_PrologueTestFlag",
+             "44 88 44 24 18 53 48 83 EC ?? 0F B6 C2 48 8B D9 80 BC ?? ?? ?? ?? ?? 00",
+             ResolveMode::Direct, 0, 0},
+            {"OverlayShow_P2_TestThroughClear",
+             "44 88 44 24 18 53 48 83 EC ?? 0F B6 C2 48 8B D9 80 BC ?? ?? ?? ?? ?? 00 ?? ?? C6 84 ?? ?? ?? ?? ?? 00 E8",
+             ResolveMode::Direct, 0, 0},
+            {"OverlayShow_P3_BodyTestClear",
+             "0F B6 C2 48 8B D9 80 BC ?? ?? ?? ?? ?? 00 ?? ?? C6 84 ?? ?? ?? ?? ?? 00 E8 ?? ?? ?? ?? 84 C0",
+             ResolveMode::Direct, -0x0A, 0},
+        };
+
+        // --- UI menu-open entry (vftable[1]) --------------------------------
+        // Direct entry hook. P1 anchors directly on the entry prologue through
+        // the `cmp byte [rsi+670h], 0` field test. P2 is the mid-body anchor on the
+        // vtable call that precedes lea "SetInputId" and walks back 0x36 to the
+        // entry. P3 anchors on the field-test branch pair and walks back 0x1C. Jcc
+        // rel32 displacements are wildcarded.
+        inline constexpr AddrCandidate k_menuOpenCandidates[] = {
+            {"MenuOpen_P1_EntryFieldTest",
+             "48 89 5C 24 10 48 89 74 24 18 55 57 41 56 48 8B EC 48 83 EC 50 48 8D 71 A8 44 8A F2 80 BE 70 06 00 00 00",
+             ResolveMode::Direct, 0, 0},
+            {"MenuOpen_P2_VtableCallSetInput",
+             "48 8B 41 B0 48 8B 48 30 48 8B 01 FF 10 48 8D 15 ?? ?? ?? ??",
+             ResolveMode::Direct, -0x36, 0},
+            {"MenuOpen_P3_FieldTestBranch",
+             "80 BE 70 06 00 00 00 48 8B F9 0F 84 ?? ?? ?? ?? 80 79 48 00 0F 85",
+             ResolveMode::Direct, -0x1C, 0},
+        };
+
+        // --- UI menu-close entry (vftable[2]) -------------------------------
+        // Direct entry hook. P1 anchors on the entry prologue through the
+        // `cmp byte [rsi+0A0h], 0` field test. P2 is the mid-body anchor on the
+        // deactivate store (`mov byte [rbx+49h], 0; call;
+        // mov byte [rbx+48h], 0`) with the register ModRM bytes wildcarded so it
+        // matches whether the object is held in rbx or rdi; it walks back 0x18E.
+        // P3 anchors on the field-test branch and walks back 0x0F.
+        inline constexpr AddrCandidate k_menuCloseCandidates[] = {
+            {"MenuClose_P1_EntryFieldTest",
+             "48 89 5C 24 18 48 89 74 24 20 57 48 83 EC 30 48 8D 71 A8 48 8B D9 80 BE A0 00 00 00 00",
+             ResolveMode::Direct, 0, 0},
+            {"MenuClose_P2_DeactivateStore",
+             "8A ?? 48 48 8D ?? 28 C6 ?? 49 00 E8 ?? ?? ?? ?? C6 ?? 48 00",
+             ResolveMode::Direct, -0x18E, 0},
+            {"MenuClose_P3_FieldTestBranch",
+             "48 8D 71 A8 48 8B D9 80 BE A0 00 00 00 00 0F 84 ?? ?? ?? ?? E8",
+             ResolveMode::Direct, -0x0F, 0},
+        };
+    } // namespace Aob
+} // namespace TPVCamera
+
+#endif // TPVCAMERA_AOB_RESOLVER_HPP

--- a/TPVCamera/src/constants.hpp
+++ b/TPVCamera/src/constants.hpp
@@ -2,9 +2,11 @@
  * @file constants.hpp
  * @brief Central definitions for constants used throughout the mod.
  *
- * Includes version info, filenames, AOB patterns, and memory offsets. Memory
- * locations are resolved via AOB patterns so they survive game updates. Static
- * vtable/code addresses are translated to runtime via module_base + (static - IMAGE_BASE).
+ * Includes version info, filenames, memory offsets, RTTI type names, and engine
+ * flag values. Code/data locations are resolved by the multi-candidate AOB
+ * cascades in aob_resolver.hpp so they survive game updates; the few static
+ * vtable/code addresses kept here are translated to runtime via
+ * module_base + (static - IMAGE_BASE) and serve only as last-resort fallbacks.
  */
 #ifndef TPVCAMERA_CONSTANTS_HPP
 #define TPVCAMERA_CONSTANTS_HPP
@@ -51,56 +53,13 @@ namespace Constants
     /** @brief Default logging level ("INFO"). */
     constexpr const char *DEFAULT_LOG_LEVEL = "INFO";
 
-    // --- AOB (Array-of-Bytes) Patterns ---
-
-    // Fast-path return of the TLS-guarded accessor (sub_18091C138) that yields the global context /
-    // entity-subsystem registry pointer (qword_18549B4B0). Its +0x38 slot is the camera-manager root the
-    // game-state detection walks (see OFFSET_MANAGER_PTR_STORAGE); game_interface.cpp resolves the RIP-relative
-    // MOV (two bytes past the match) to that storage slot.
-    //   WHGame.DLL+91C15F - 7F 0D                 - jg short loc_18091C16E
-    //   WHGame.DLL+91C161 - 48 8B 05 ?? ?? ?? ??  - mov rax, [qword_18549B4B0]
-    //   WHGame.DLL+91C168 - 48 83 C4 20           - add rsp, 20h
-    //   WHGame.DLL+91C16C - 5B                    - pop rbx
-    //   WHGame.DLL+91C16D - C3                    - ret
-    // The leading `jg` is a short Jcc rel8, normally a weak anchor (the rel8/rel32 encoding can flip), but
-    // here it only skips the 13-byte fast-path epilogue (mov+add+pop+ret) -- a fixed distance far inside rel8
-    // range -- so the encoding is stable. It is also load-bearing: the mov+epilogue tail alone is NOT unique
-    // (sibling magic-static accessors share it); only the preceding `jg` (the guard's signed-greater compare)
-    // isolates this site.
-    /**
-     * @brief AOB anchored on the global-context accessor's fast-path return. The RIP-relative MOV two bytes
-     *        into the match loads the global context / camera-manager-root pointer.
-     */
-    constexpr const char *CONTEXT_PTR_LOAD_AOB_PATTERN =
-        "7F ?? 48 8B 05 ?? ?? ?? ?? 48 83 C4 ?? 5B C3";
-
-    // AOB for the camera frustum-builder (CCamera::UpdateFrustumPlanes). It reads the
-    // camera's 3x4 matrix (rcx -> matrix at +0) and computes the world-space cull
-    // planes from it. This is the hook target for the third-person camera:
-    // the offset must be applied to the camera matrix HERE, before the cull planes are
-    // computed, so culling matches the third-person view (offsetting only the rendered
-    // matrix afterwards leaves the frustum culling from the eye, which hides nearby
-    // geometry). Every gameplay camera (first-person, combat via its private inner
-    // camera, mount) funnels into this builder for the active CView, so one gated hook
-    // covers them all.
-    //
-    // This function has many callers (shadow, reflection, and portal cameras all rebuild
-    // their frustums here), so the detour must gate to the game view camera by checking
-    // that (camera - SVIEWPARAMS_VIEWMATRIX_OFFSET), the CView that embeds it, carries
-    // the CView vtable.
-    //
-    // Signature: __int64 __fastcall(camera /*rcx*/). Prologue:
-    //   WHGame.DLL+537E04 - 48 8B C4              - mov rax,rsp
-    //   WHGame.DLL+537E07 - 55 53 56 57 41 54 41 55 41 56 41 57 - push rbp/rbx/rsi/rdi/r12..r15
-    //   WHGame.DLL+537E13 - 48 8D 68 98           - lea rbp,[rax-68]
-    //   WHGame.DLL+537E17 - 48 81 EC 28 01 00 00  - sub rsp,128
-    //   WHGame.DLL+537E1E - F3 0F 10 09           - movss xmm1,[rcx]   (read matrix)
-    //   WHGame.DLL+537E22 - 48 8B D9              - mov rbx,rcx        (camera)
-    //
-    // The lea displacement and the sub-rsp immediate are wildcarded for frame-size
-    // resilience; the matrix layout and the call signature are stable across patches.
-    constexpr const char *FRUSTUM_BUILD_AOB_PATTERN =
-        "48 8B C4 55 53 56 57 41 54 41 55 41 56 41 57 48 8D 68 ?? 48 81 EC ?? ?? 00 00 F3 0F 10 09 48 8B D9";
+    // All AOB signatures are defined as multi-candidate cascades in aob_resolver.hpp
+    // (k_contextCandidates, k_frustumCandidates, ...). The global-context cascade
+    // resolves the storage slot whose +0x38 reaches the camera-manager root the
+    // game-state detection walks (see OFFSET_MANAGER_PTR_STORAGE); the frustum-builder
+    // cascade resolves CCamera::UpdateFrustumPlanes, the matrix-offset hook target that
+    // every gameplay camera funnels through (gated to the game view by the embedding
+    // CView vtable, camera - SVIEWPARAMS_VIEWMATRIX_OFFSET).
 
     // Static image base of WHGame.DLL; used to translate static vtable/code addresses
     // into runtime addresses (runtime = module_base + (static - IMAGE_BASE)).
@@ -115,7 +74,7 @@ namespace Constants
 
     // Player look/aim orientation chain. Used to LEVEL the aim pitch while free-look orbit is active
     // so the character's head and the eye look forward (not just the camera). Chain:
-    //   g_env (GENV_STATIC) -> p_game (g_env + GENV_PGAME_OFFSET)
+    //   g_env base (k_genvCandidates cascade) -> p_game (g_env + GENV_PGAME_OFFSET)
     //   -> CCryAction = p_game->IGame::GetIGameFramework() (vtable slot 16 = IGAME_GET_FRAMEWORK_VTABLE_OFFSET)
     //   -> p_action_game (CCryAction + CCRYACTION_ACTIONGAME_OFFSET)
     //   -> C_Player    (p_action_game + CACTIONGAME_LOCAL_ACTOR_OFFSET), validated by its RTTI type name
@@ -125,21 +84,11 @@ namespace Constants
     // The look quaternion the cameras read (controller + 0x24) is DERIVED from this scalar pitch+yaw
     // EVERY frame, so writing that quat is overwritten -- the SCALAR pitch is what must be written to
     // level the aim. Both copies are written so any internal current/target smoothing also settles at level.
-    // g_env (SSystemGlobalEnvironment) base. Resolved patch-resiliently at startup from a
-    // `lea rdx, [g_env]` instruction via GENV_LOAD_AOB_PATTERN; this static RVA is only the
-    // fallback used if that AOB ever drifts.
+    // g_env (SSystemGlobalEnvironment) base. Resolved patch-resiliently at startup from
+    // `lea/mov [rip+g_env]` reference sites via the k_genvCandidates cascade
+    // (aob_resolver.hpp); this static RVA is only the fallback used if every candidate
+    // ever drifts.
     constexpr uintptr_t GENV_STATIC = 0x18492B800;
-    // Unique AOB whose `lea rdx, [g_env]` resolves the g_env base. The lea is at +3 (disp32 at
-    // +6, instruction length 7); the window spans the following
-    // `mov rcx,[rip]; mov rax,[rcx]; call [rax+18h]` tail to stay unique. The two RIP
-    // displacements and the call rel32 are wildcarded so only opcodes anchor the match.
-    constexpr const char *GENV_LOAD_AOB_PATTERN =
-        "4C 8B C7 48 8D 15 ?? ?? ?? ?? 48 8B CB E8 ?? ?? ?? ?? 48 8B 0D ?? ?? ?? ?? 48 8B D3 48 8B 01 FF 50 18";
-    // Byte offset of the `lea rdx, [g_env]` inside a GENV_LOAD_AOB_PATTERN match, and the
-    // disp32 offset / length of that lea, fed to Scanner::resolve_rip_relative.
-    constexpr ptrdiff_t GENV_LOAD_AOB_LEA_OFFSET = 3;
-    constexpr ptrdiff_t GENV_LOAD_LEA_DISP_OFFSET = 3;
-    constexpr size_t GENV_LOAD_LEA_LENGTH = 7;
     // RTTI type-descriptor name of C_Player, used to validate the resolved actor (replaces a
     // hardcoded vtable address so the check survives patches).
     constexpr const char *C_PLAYER_RTTI_NAME = ".?AVC_Player@entitymodule@wh@@";
@@ -177,50 +126,30 @@ namespace Constants
     constexpr ptrdiff_t ANIMCHAR_OVERRIDE_ROT_ACTIVE_OFFSET = 0x1D8; // BYTE, set to 1 each frame (consume-once)
     constexpr ptrdiff_t ANIMCHAR_OVERRIDE_ROT_QUAT_OFFSET = 0x1DC;   // world Quat XYZW (16 bytes)
 
-    // AOB for the head-visibility setter (signature void __fastcall(this /*rcx*/,
-    // bool hide_head /*dl*/, char flags /*r8b*/)). The first-person rig hides the
-    // player head; forcing hide_head to false keeps it visible while the third-person
-    // offset is rendering so the player is not headless from behind.
-    //   WHGame.DLL+1356EDC - 48 89 5C 24 10        - mov [rsp+10],rbx
-    //   WHGame.DLL+1356EE1 - 48 89 74 24 18        - mov [rsp+18],rsi
-    //   WHGame.DLL+1356EE6 - 57                    - push rdi
-    //   WHGame.DLL+1356EE7 - 48 83 EC ??           - sub rsp,frame
-    //   WHGame.DLL+1356EEB - 41 8A F0              - mov sil,r8b
-    constexpr const char *SET_HEAD_VISIBILITY_AOB_PATTERN =
-        "48 89 5C 24 10 48 89 74 24 18 57 48 83 EC ?? 41 8A F0";
+    // The head-visibility setter (k_headVisibilityCandidates) has signature
+    // void __fastcall(this /*rcx*/, bool hide_head /*dl*/, char flags /*r8b*/). The
+    // first-person rig hides the player head; forcing hide_head to false keeps it
+    // visible while the third-person offset is rendering so the player is not headless
+    // from behind.
 
-    // Global action dispatcher (sub_1808EBEE4): the C++ source of Lua Player:OnAction. Fires once per
-    // action-map action with its name and post-action-map value:
+    // Global action dispatcher (k_actionDispatchCandidates): the C++ source of Lua Player:OnAction. Fires
+    // once per action-map action with its name and post-action-map value:
     //   _QWORD*(this /*rcx*/, const char** action_name /*rdx*/, uint activation /*r8d*/, float value /*xmm3*/)
     // The value is device-agnostic (keyboard, gamepad and rebinds all funnel through the same action
     // name), so reading the xi_movey / xi_movex axis here gives movement INTENT -- nonzero while a key is
-    // held even when a wall arrests the body, which the body-position speed cannot distinguish. Prologue
-    // anchor: `movss [rax+20h], xmm3` (stores the float value arg) + push rbp/rdi/r14; the trailing lea
-    // offset and stack size are wildcarded so a patch that shifts the frame size still matches.
-    constexpr const char *ACTION_DISPATCH_AOB_PATTERN =
-        "48 8B C4 48 89 58 10 48 89 70 18 F3 0F 11 58 20 55 57 41 56 48 8D 68 ?? 48 81 EC ?? ?? ?? ??";
+    // held even when a wall arrests the body, which the body-position speed cannot distinguish.
     // The movement action names are matched in player_onaction_hook.cpp (a small candidate list across the
     // xi_* / movement_* / move* action maps); a trace-level probe there logs each distinct action name once so
     // the on-foot movement axis vocabulary can be confirmed at runtime.
 
     // --- Physics world raycast (camera collision + aim convergence) ---
-    // IPhysicalWorld::RayWorldIntersection inline helper (sub_180484944). Casts a world
-    // ray and fills a ray_hit; returns the hit count. Signature (Microsoft x64):
+    // IPhysicalWorld::RayWorldIntersection inline helper (k_rayWorldIntersectionCandidates). Casts a
+    // world ray and fills a ray_hit; returns the hit count. Signature (Microsoft x64):
     //   int(this /*rcx = p_physical_world*/, const Vec3* org /*rdx*/, const Vec3* dir /*r8*/,
     //       int objtypes /*r9d*/, uint flags, ray_hit* hits, int n_max_hits, void* p_skip_ents,
     //       int n_skip_ents, void* p_foreign_data, int i_foreign_data, const char* p_name_tag)
-    // dir is NOT normalized -- its length is the maximum ray length, and ray_hit.dist is
-    // the world-space distance to the hit. A sibling helper (sub_1838D6E3C) shares this exact
-    // prologue and its first inner call, then diverges in how it stages the next call's arguments,
-    // so the prologue window alone matches both. The pattern extends past that shared call into the
-    // body, where this helper does `mov r9d, imm32` while the sibling does `mov rcx, r9` -- that
-    // opcode difference isolates sub_180484944 to a single match. The prologue lea displacement, the
-    // sub-rsp immediate, the two frame-local lea displacements, the shared call rel32, and the r9d
-    // immediate are all wildcarded so only opcodes anchor the match.
-    constexpr const char *RAY_WORLD_INTERSECTION_AOB_PATTERN =
-        "48 8B C4 48 89 58 08 48 89 70 10 48 89 78 18 4C 89 70 20 55 48 8D 68 ?? 48 81 EC ?? ?? 00 00 "
-        "48 8B DA 49 8B F8 33 D2 4C 8B F1 48 8D 4D ?? 41 8B F1 44 8D 42 70 E8 ?? ?? ?? ?? 8B 43 08 "
-        "48 8D 55 ?? F2 0F 10 03 41 B9 ?? ?? ?? ??";
+    // dir is NOT normalized -- its length is the maximum ray length, and ray_hit.dist is the
+    // world-space distance to the hit.
 
     // p_physical_world (IPhysicalWorld*) is a member of the g_env struct: its slot address is
     // g_env + PHYSICAL_WORLD_OFFSET. It is derived from the patch-resiliently resolved g_env
@@ -269,7 +198,23 @@ namespace Constants
     // sets rwi_colltype_any so the ray reports hits whatever the surface collision class; without
     // it a surface that does not match the default collision filter is skipped (a phantom miss
     // that let the camera/crosshair punch through). It only adds valid hits, never removes them.
-    constexpr unsigned int RWI_FLAGS_STOP_AT_SOLID = 0x40F;
+    //
+    // The high word adds an explicit geometry collide-type request: geom_colltype_ray (0x00020000) |
+    // geom_colltype_player (0x80000000). Fabric tent/awning/stall ROOFS in KCD2 are static collision-PROXY
+    // meshes flagged geom_colltype_player but NOT geom_colltype_ray (MTL_FLAG_COLLISION_PROXY), so a plain
+    // colltype_any ray slid straight through them and the third-person camera buried itself in the cloth.
+    // Requesting ray|player colltype makes RayWorldIntersection report those proxies, so the camera collides
+    // with fabric roofs while still hitting normal world geometry (objtypes stay RWI_OBJTYPES_CAMERA 0x101).
+    // Verified live on retail 1.5.5. (See docs/analysis/foliage_occlusion_findings.md.)
+    //
+    // Composed from the named physinterface.h bit values rather than a magic literal so the intent is
+    // self-documenting and each contributing flag is independently auditable.
+    constexpr unsigned int RWI_STOP_AT_PIERCEABLE = 0x0000000F; // stop at the first solid (non-pierceable) hit
+    constexpr unsigned int RWI_COLLTYPE_ANY = 0x00000400;       // report a hit whatever the surface collision class
+    constexpr unsigned int GEOM_COLLTYPE_RAY = 0x00020000;      // request geometry flagged as ray-collidable
+    constexpr unsigned int GEOM_COLLTYPE_PLAYER = 0x80000000;   // also request player-collidable proxies (fabric roofs)
+    constexpr unsigned int RWI_FLAGS_STOP_AT_SOLID =
+        RWI_STOP_AT_PIERCEABLE | RWI_COLLTYPE_ANY | GEOM_COLLTYPE_RAY | GEOM_COLLTYPE_PLAYER; // 0x8002040F
 
     // --- Swept-sphere camera collision (IPhysicalWorld::PrimitiveWorldIntersection) ---
     // A single thin RayWorldIntersection ray to a sweeping endpoint (the camera rotates+moves
@@ -326,97 +271,38 @@ namespace Constants
     // interaction call comes from C_PlayerInteractor look-ray builder sub_1808333C8 (which reads the
     // gameplay camera pos@+60 / rotation@+72 and forms origin@interactor+0x3E8 / dir@+0x3F4).
     //
-    // INTERACTION_RAY_BUILD = sub_180530584 entry (the query builder we hook; no RIP-relative bytes).
-    constexpr const char *INTERACTION_RAY_BUILD_AOB_PATTERN =
-        "F2 0F 10 02 4C 8B D1 4C 8B 5C 24 30 F2 0F 11 01 8B 42 08 89 41 08 F2 41 0F 10 00";
-    // INTERACTOR_LOOKRAY = sub_1808333C8 entry. Used only to bound the call site: the builder hook acts
-    // only when its return address lies inside this function, so other (camera/AI/audio) ray queries are
-    // never touched. The look-ray call sits ~0x259 in; the bound covers the whole function.
-    constexpr const char *INTERACTOR_LOOKRAY_AOB_PATTERN =
-        "48 8B C4 48 89 58 10 48 89 70 18 55 57 41 54 41 56 41 57 48 8D A8 ?? ?? FF FF 48 81 EC ?? ?? "
-        "00 00 0F 29 70 C8 0F 29 78 B8 44 0F 29 40 A8 44 0F 29 50 98 44 0F 29 58 88";
+    // k_interactionRayBuildCandidates resolves the query builder entry (the function the mod hooks).
+    // k_interactorLookRayCandidates resolves the look-ray builder entry, used only to bound the call
+    // site: the builder hook acts only when its return address lies inside [entry, entry +
+    // INTERACTOR_LOOKRAY_SPAN), so other (camera/AI/audio) ray queries are never touched.
     constexpr size_t INTERACTOR_LOOKRAY_SPAN = 0x500; // caller-range bound for the return-address filter
     // The dir argument (r8 / a3) points at a Vec3 (x,y,z) whose length is the ray reach; the redirect rewrites
     // x,y,z to the crosshair forward and preserves the reach. The origin (rdx / a2) Vec3 is slid forward along
     // that same ray to the player-eye projection (see redirect_interaction_ray), so the engine's interaction
     // range cap is measured from ~eye rather than from the camera standing FollowDistance behind.
 
-    // INTERACTION_ONSCREEN_CHECK = sub_18093C170: projects a candidate's world interaction point through the
-    // gameplay camera (qword_18492B908) and rejects it when it falls outside the on-screen reticle range.
-    // The single gate that drops the shrine when the body is not turned -- it projects
-    // off-reticle in the gameplay camera even though centered in the offset render view. The hook force-passes
-    // ONLY candidates whose world point lies along the published crosshair ray (perp distance below the max
-    // below); all others fall through to the original. Args: a1=rcx a2=rdx(&worldPoint Vec3) a3=r8(&out 2D
-    // screen coords, written) a4=r9(config). Prologue ends with mov rcx,[rip+disp] -> qword_18492B908.
-    constexpr const char *INTERACTION_ONSCREEN_CHECK_AOB_PATTERN =
-        "4C 8B DC 49 89 5B 10 49 89 73 18 49 89 4B 08 57 48 83 EC ?? 48 8B 0D ?? ?? ?? ?? 49 8D 70 04";
+    // k_interactionOnScreenCandidates resolves the on-screen reticle gate: it projects a candidate's
+    // world interaction point through the gameplay camera and rejects it when it falls outside the
+    // on-screen reticle range. This is the single gate that drops the shrine when the body is not
+    // turned (it projects off-reticle in the gameplay camera even though centered in the offset render
+    // view). The hook force-passes ONLY candidates whose world point lies along the published crosshair
+    // ray (perp distance below the max below); all others fall through to the original. Args: a1=rcx
+    // a2=rdx(&worldPoint Vec3) a3=r8(&out 2D screen coords, written) a4=r9(config).
     constexpr float INTERACTION_ONSCREEN_RAY_PERP_MAX = 0.85f; // m; max perp distance to the crosshair ray
     constexpr float INTERACTION_ONSCREEN_CENTER = 50.0f;       // screen-center coord (priority = dist from it)
 
-    // AOB patterns for direct UI overlay hooks. The camera reads overlay_state().active to
-    // suppress the offset while an overlay (inventory, map, dialog, codex) is up.
-    // sub_1808C3AFC (HideOverlays):
-    //   WHGame.DLL+8C3AFC - 44 88 44 24 18          - mov [rsp+18h], r8b
-    //   WHGame.DLL+8C3B01 - 53                      - push rbx
-    //   WHGame.DLL+8C3B02 - 48 83 EC 20             - sub rsp, 20h
-    //   WHGame.DLL+8C3B06 - 0F B6 C2                - movzx eax, dl
-    //   WHGame.DLL+8C3B09 - 48 8B D9                - mov rbx, rcx
-    //   WHGame.DLL+8C3B0C - 48 8D 15 ?? ?? ?? ??    - lea rdx, ["HideOverlays"]
-    //   WHGame.DLL+8C3B13 - C6 84 08 B8 00 00 00 01 - mov byte ptr [rax+rcx+0B8h], 1
-    constexpr const char *UI_OVERLAY_HIDE_AOB_PATTERN =
-        "44 88 44 24 18 53 48 83 EC ?? 0F B6 C2 48 8B D9 48 8D 15 ?? ?? ?? ?? C6 84 ?? ?? ?? ?? ?? 01";
+    // The UI overlay hooks (k_overlayHideCandidates / k_overlayShowCandidates) bracket
+    // HideOverlays / ShowOverlays. The camera reads overlay_state().active to suppress the offset
+    // while an overlay (inventory, map, dialog, codex) is up.
 
-    // sub_1808C3BB8 (ShowOverlays):
-    //   WHGame.DLL+8C3BB8 - 44 88 44 24 18          - mov [rsp+18h], r8b
-    //   WHGame.DLL+8C3BBD - 53                      - push rbx
-    //   WHGame.DLL+8C3BBE - 48 83 EC 20             - sub rsp, 20h
-    //   WHGame.DLL+8C3BC2 - 0F B6 C2                - movzx eax, dl
-    //   WHGame.DLL+8C3BC5 - 48 8B D9                - mov rbx, rcx
-    //   WHGame.DLL+8C3BC8 - 80 BC 08 B8 00 00 00 00 - cmp byte ptr [rax+rcx+0B8h], 0
-    //   WHGame.DLL+8C3BD0 - 74 48                   - jz short loc_1808C3C1A
-    // The sub-rsp immediate is wildcarded (frame resilience) and the pattern deliberately stops
-    // before the trailing `jz short`: a Jcc rel8 opcode can flip to the rel32 form across patches,
-    // and the cmp byte ptr [rax+rcx+0B8h], 0 prefix is already unique on its own.
-    constexpr const char *UI_OVERLAY_SHOW_AOB_PATTERN =
-        "44 88 44 24 18 53 48 83 EC ?? 0F B6 C2 48 8B D9 80 BC ?? ?? ?? ?? ?? 00";
+    // The UI menu hooks (k_menuOpenCandidates / k_menuCloseCandidates) bracket the menu-open
+    // (vftable[1]) and menu-close (vftable[2]) entries.
 
-    // --- UI Menu Hook Patterns ---
-    // Inside sub_180C0B618 (UI menu open, vftable[1]):
-    //   WHGame.DLL+C0B64E - 48 8B 41 B0           - mov rax, [rcx-50h]
-    //   WHGame.DLL+C0B652 - 48 8B 48 30           - mov rcx, [rax+30h]
-    //   WHGame.DLL+C0B656 - 48 8B 01              - mov rax, [rcx]
-    //   WHGame.DLL+C0B659 - FF 10                 - call qword ptr [rax]
-    //   WHGame.DLL+C0B65B - 48 8D 15 ?? ?? ?? ??  - lea rdx, ["SetInputId"]
-    /** @brief AOB pattern for UI menu open function (vftable[1]). */
-    constexpr const char *UI_MENU_OPEN_AOB_PATTERN =
-        "48 8B 41 B0 48 8B 48 30 48 8B 01 FF 10 48 8D 15 ?? ?? ?? ??";
-
-    // Inside sub_180C0B260 (UI menu close, vftable[2]); the register ModRM bytes are wildcarded so the pattern
-    // matches regardless of whether the build holds the object in rbx (as below) or rdi:
-    //   WHGame.DLL+C0B3EE - 8A 53 48              - mov dl, [rbx+48h]
-    //   WHGame.DLL+C0B3F1 - 48 8D 4B 28           - lea rcx, [rbx+28h]
-    //   WHGame.DLL+C0B3F5 - C6 43 49 00           - mov byte ptr [rbx+49h], 0
-    //   WHGame.DLL+C0B3F9 - E8 ?? ?? ?? ??        - call sub_180393794
-    //   WHGame.DLL+C0B3FE - C6 43 48 00           - mov byte ptr [rbx+48h], 0
-    /** @brief AOB pattern for UI menu close function (vftable[2]). */
-    constexpr const char *UI_MENU_CLOSE_AOB_PATTERN =
-        "8A ?? 48 48 8D ?? 28 C6 ?? 49 00 E8 ?? ?? ?? ?? C6 ?? 48 00";
-
-    // Generic input-event dispatcher: void __fastcall(controller /*rcx*/, event /*rdx*/,
-    // char /*r8b*/). Every input event (movement and look, FPV and TPV) funnels through
-    // here. The free-look hooks it to capture the mouse-look delta and freeze
-    // look input while orbiting. The event layout matches the INPUT_EVENT_* offsets below
-    // (type at INPUT_EVENT_TYPE_OFFSET == MOUSE_INPUT_TYPE_ID for mouse, id at
-    // INPUT_EVENT_ID_OFFSET, delta float at INPUT_EVENT_VALUE_OFFSET).
-    //   mov [rsp+8],rbx; push rdi; sub rsp,30; mov rbx,rdx (event); mov rdi,rcx (ctrl);
-    //   test r8b,r8b; jnz; cmp [rcx+0xD8],r8b; jz ...
-    // The sub-rsp immediate and the jnz rel8 displacement (the skip over the cmp+jz block) are
-    // wildcarded for patch resilience. The jnz OPCODE byte is kept literal: it only skips that fixed
-    // 13-byte block (cmp + jz rel32), far inside rel8 range, so the encoding stays the 2-byte 75 form
-    // across builds (same reasoning as the CONTEXT_PTR_LOAD jg anchor). The cmp [rcx+0xD8],r8b
-    // landmark keeps the match unique.
-    constexpr const char *INPUT_DISPATCHER_AOB_PATTERN =
-        "48 89 5C 24 08 57 48 83 EC ?? 48 8B DA 48 8B F9 45 84 C0 75 ?? 44 38 81 D8 00 00 00 0F 84";
+    // Generic input-event dispatcher (k_inputDispatchCandidates): void __fastcall(controller /*rcx*/,
+    // event /*rdx*/, char /*r8b*/). Every input event (movement and look, FPV and TPV) funnels through
+    // here. The free-look hooks it to capture the mouse-look delta and freeze look input while orbiting.
+    // The event layout matches the INPUT_EVENT_* offsets below (type at INPUT_EVENT_TYPE_OFFSET ==
+    // MOUSE_INPUT_TYPE_ID for mouse, id at INPUT_EVENT_ID_OFFSET, delta float at INPUT_EVENT_VALUE_OFFSET).
 
     // Look-axis event ids (SInputEvent.keyId / EKeyId, KCD-renumbered) matched on the analog look channel
     // together with MOUSE_INPUT_TYPE_ID below (which is actually EInputState::eIS_Changed, NOT a device

--- a/TPVCamera/src/game_interface.cpp
+++ b/TPVCamera/src/game_interface.cpp
@@ -8,7 +8,7 @@
  */
 
 #include "game_interface.hpp"
-#include "constants.hpp"
+#include "aob_resolver.hpp"
 #include "global_state.hpp"
 
 #include <DetourModKit.hpp>
@@ -28,31 +28,24 @@ bool initialize_game_interface(uintptr_t module_base, size_t module_size)
     {
         logger.info("GameInterface: Initializing with dynamic AOB scanning...");
 
-        auto ctx_pat = DMK::Scanner::parse_aob(Constants::CONTEXT_PTR_LOAD_AOB_PATTERN);
-        if (!ctx_pat.has_value())
+        // The cascade's RipRelative candidates each resolve the same global-context storage slot
+        // (the RIP-relative MOV/load target), so the returned address is the slot directly.
+        const uintptr_t ctx_slot = resolve_address(Aob::k_contextCandidates, "GlobalContextPtr");
+        if (ctx_slot == 0)
         {
-            throw std::runtime_error("Failed to parse context pointer AOB pattern");
+            throw std::runtime_error("Context pointer cascade did not resolve");
         }
 
-        const std::byte *ctx_aob = DMK::Scanner::find_pattern(reinterpret_cast<const std::byte *>(module_base), module_size, *ctx_pat);
-        if (!ctx_aob)
+        // The storage slot lives in the game image; reject a resolution that lands outside it.
+        const uintptr_t module_end = module_base + module_size;
+        if (ctx_slot < module_base || ctx_slot >= module_end)
         {
-            throw std::runtime_error("Context pointer AOB pattern not found");
+            throw std::runtime_error("Context pointer storage resolved outside module bounds");
         }
 
-        logger.debug("GameInterface: Found context AOB at {}", format_address(reinterpret_cast<uintptr_t>(ctx_aob)));
+        g_global_context_ptr_address = reinterpret_cast<std::byte *>(ctx_slot);
 
-        // Resolve RIP-relative target: mov rax, [rip + offset] (48 8B 05 xx xx xx xx).
-        // The AOB match is 2 bytes before the MOV instruction.
-        auto ctx_target_addr = DMK::Scanner::resolve_rip_relative(ctx_aob + 2, 3, 7);
-        if (!ctx_target_addr.has_value())
-        {
-            throw std::runtime_error("Failed to resolve context pointer RIP-relative address");
-        }
-
-        g_global_context_ptr_address = reinterpret_cast<std::byte *>(ctx_target_addr.value());
-
-        logger.info("GameInterface: Global context pointer storage at {}", format_address(ctx_target_addr.value()));
+        logger.info("GameInterface: Global context pointer storage at {}", format_address(ctx_slot));
 
         return true;
     }

--- a/TPVCamera/src/hooks/camera_hook.cpp
+++ b/TPVCamera/src/hooks/camera_hook.cpp
@@ -24,6 +24,7 @@
  */
 
 #include "camera_hook.hpp"
+#include "aob_resolver.hpp"
 #include "constants.hpp"
 #include "config.hpp"
 #include "global_state.hpp"
@@ -1908,35 +1909,24 @@ static void __fastcall detour_input_dispatch(uintptr_t controller, uintptr_t inp
 
 /**
  * @brief Resolves the SSystemGlobalEnvironment (g_env) base, patch-resiliently.
- * @details Anchors on a unique `lea rdx, [g_env]` instruction (GENV_LOAD_AOB_PATTERN) and
- *          resolves its RIP-relative target, so the address survives game patches that shift
- *          the RVA. Falls back to the known static RVA if the AOB ever drifts, so the camera
- *          still functions on the build it was authored against. The result is screened as a
- *          plausible user-space pointer before it is accepted.
- * @return The g_env base address (AOB result, or the static fallback).
+ * @details Resolves the g_env base from the k_genvCandidates cascade (each candidate is a
+ *          RIP-relative lea/mov [rip+g_env] reference site), so the address survives game
+ *          patches that shift the RVA. Falls back to the known static RVA if every candidate
+ *          drifts, so the camera still functions on the build it was authored against. The
+ *          result is screened as a plausible user-space pointer before it is accepted.
+ * @return The g_env base address (cascade result, or the static fallback).
  */
-static uintptr_t resolve_genv(uintptr_t module_base, size_t module_size)
+static uintptr_t resolve_genv(uintptr_t module_base)
 {
     DMK::Logger &logger = DMK::Logger::get_instance();
 
-    auto pattern = DMK::Scanner::parse_aob(Constants::GENV_LOAD_AOB_PATTERN);
-    if (pattern.has_value())
+    // The cascade's RipRelative candidates each resolve the g_env base from a different
+    // lea/mov [rip+g_env] reference site; the result is screened as a plausible pointer.
+    const uintptr_t resolved = resolve_address(Aob::k_genvCandidates, "Genv");
+    if (resolved != 0 && DMK::Memory::plausible_userspace_ptr(resolved))
     {
-        const std::byte *match = DMK::Scanner::find_pattern(
-            reinterpret_cast<const std::byte *>(module_base), module_size, *pattern);
-        if (match)
-        {
-            // The lea is GENV_LOAD_AOB_LEA_OFFSET bytes into the match; resolve its disp32.
-            const auto resolved = DMK::Scanner::resolve_rip_relative(
-                match + Constants::GENV_LOAD_AOB_LEA_OFFSET,
-                Constants::GENV_LOAD_LEA_DISP_OFFSET,
-                Constants::GENV_LOAD_LEA_LENGTH);
-            if (resolved.has_value() && DMK::Memory::plausible_userspace_ptr(*resolved))
-            {
-                logger.info("Camera: g_env resolved via AOB at {}", DMK::Format::format_address(*resolved));
-                return *resolved;
-            }
-        }
+        logger.info("Camera: g_env resolved via AOB at {}", DMK::Format::format_address(resolved));
+        return resolved;
     }
 
     const uintptr_t fallback = module_base + (Constants::GENV_STATIC - Constants::IMAGE_BASE);
@@ -1958,7 +1948,7 @@ bool initialize_camera(uintptr_t module_base, size_t module_size)
 
     // Resolve g_env once (patch-resilient AOB, static RVA fallback). The CView vtable is
     // identified lazily by RTTI on the first game-view camera, so nothing is resolved here.
-    s_genv_runtime = resolve_genv(module_base, module_size);
+    s_genv_runtime = resolve_genv(module_base);
 
     // Resolve the engine ray helper for collision + aim convergence. Best-effort: on a miss
     // those features no-op (the camera still renders), so the result is intentionally discarded.
@@ -1968,14 +1958,21 @@ bool initialize_camera(uintptr_t module_base, size_t module_size)
     {
         DMK::HookManager &hook_manager = DMK::HookManager::get_instance();
 
+        // resolve_cascade scans every executable region, not just this module, so each resolved
+        // entry is screened against the game image bounds before it is hooked (a mid-body
+        // walk-back candidate could otherwise land an entry on a future cross-module collision).
+        const uintptr_t module_end = module_base + module_size;
+
         // Hook the camera frustum builder -- the matrix-offset point; without it the feature
-        // does nothing. Located by AOB at the function prologue (offset 0 into the match).
-        auto frustum_result = hook_manager.create_inline_hook_aob(
+        // does nothing. Resolved by the frustum cascade to the function entry.
+        const uintptr_t frustum_addr = resolve_address(Aob::k_frustumCandidates, "CameraFrustumBuild");
+        if (frustum_addr == 0 || frustum_addr < module_base || frustum_addr >= module_end)
+        {
+            throw std::runtime_error("Failed to resolve frustum builder cascade inside module bounds");
+        }
+        auto frustum_result = hook_manager.create_inline_hook(
             "CameraFrustumBuild",
-            module_base,
-            module_size,
-            Constants::FRUSTUM_BUILD_AOB_PATTERN,
-            0,
+            frustum_addr,
             reinterpret_cast<void *>(detour_frustum_build),
             reinterpret_cast<void **>(&s_frustum_build_original));
 
@@ -1987,37 +1984,47 @@ bool initialize_camera(uintptr_t module_base, size_t module_size)
 
         // The head-visibility hook is best-effort: if it fails the camera still works,
         // the player just appears headless from behind, so a miss is a warning.
-        auto head_result = hook_manager.create_inline_hook_aob(
-            "SetHeadVisibility",
-            module_base,
-            module_size,
-            Constants::SET_HEAD_VISIBILITY_AOB_PATTERN,
-            0,
-            reinterpret_cast<void *>(detour_set_head_visibility),
-            reinterpret_cast<void **>(&s_set_head_visibility_original));
-
-        if (!head_result.has_value())
+        const uintptr_t head_addr = resolve_address(Aob::k_headVisibilityCandidates, "SetHeadVisibility");
+        if (head_addr == 0 || head_addr < module_base || head_addr >= module_end)
         {
-            logger.warning("Camera: Head visibility hook failed ({}); player may appear headless from behind",
-                           DMK::Hook::error_to_string(head_result.error()));
+            logger.warning("Camera: Head visibility cascade unresolved; player may appear headless from behind");
+        }
+        else
+        {
+            auto head_result = hook_manager.create_inline_hook(
+                "SetHeadVisibility",
+                head_addr,
+                reinterpret_cast<void *>(detour_set_head_visibility),
+                reinterpret_cast<void **>(&s_set_head_visibility_original));
+
+            if (!head_result.has_value())
+            {
+                logger.warning("Camera: Head visibility hook failed ({}); player may appear headless from behind",
+                               DMK::Hook::error_to_string(head_result.error()));
+            }
         }
 
         // The input-dispatcher hook powers free-look orbit. Best-effort: a miss only
         // disables orbit, the offset camera still works. The detour is inert until the
         // orbit key is held, so it is harmless when free-look is unused.
-        auto input_result = hook_manager.create_inline_hook_aob(
-            "CameraInputDispatch",
-            module_base,
-            module_size,
-            Constants::INPUT_DISPATCHER_AOB_PATTERN,
-            0,
-            reinterpret_cast<void *>(detour_input_dispatch),
-            reinterpret_cast<void **>(&s_input_dispatch_original));
-
-        if (!input_result.has_value())
+        const uintptr_t input_addr = resolve_address(Aob::k_inputDispatchCandidates, "CameraInputDispatch");
+        if (input_addr == 0 || input_addr < module_base || input_addr >= module_end)
         {
-            logger.warning("Camera: Input dispatcher hook failed ({}); free-look orbit unavailable",
-                           DMK::Hook::error_to_string(input_result.error()));
+            logger.warning("Camera: Input dispatcher cascade unresolved; free-look orbit unavailable");
+        }
+        else
+        {
+            auto input_result = hook_manager.create_inline_hook(
+                "CameraInputDispatch",
+                input_addr,
+                reinterpret_cast<void *>(detour_input_dispatch),
+                reinterpret_cast<void **>(&s_input_dispatch_original));
+
+            if (!input_result.has_value())
+            {
+                logger.warning("Camera: Input dispatcher hook failed ({}); free-look orbit unavailable",
+                               DMK::Hook::error_to_string(input_result.error()));
+            }
         }
 
         logger.info("Camera: Third-person camera hooks installed");

--- a/TPVCamera/src/hooks/interaction_hook.cpp
+++ b/TPVCamera/src/hooks/interaction_hook.cpp
@@ -32,6 +32,7 @@
  */
 
 #include "interaction_hook.hpp"
+#include "aob_resolver.hpp"
 #include "config.hpp"
 #include "constants.hpp"
 #include "global_state.hpp"
@@ -300,36 +301,22 @@ bool initialize_interaction_hook(uintptr_t module_base, size_t module_size)
 
     try
     {
-        const auto *base = reinterpret_cast<const std::byte *>(module_base);
         const uintptr_t module_end = module_base + module_size;
 
-        // Resolve sub_1808333C8 (interactor look-ray builder) -> the caller-range filter bound.
-        auto lookray_pattern = DMK::Scanner::parse_aob(Constants::INTERACTOR_LOOKRAY_AOB_PATTERN);
-        if (!lookray_pattern.has_value())
+        // Resolve the interactor look-ray builder entry -> the caller-range filter bound.
+        // resolve_cascade scans every executable region, so confirm the resolved entry lies inside
+        // the game image: an out-of-module collision would yield a bogus return-address range.
+        const uintptr_t lookray = resolve_address(Aob::k_interactorLookRayCandidates, "InteractorLookRay");
+        if (lookray == 0 || lookray < module_base || lookray >= module_end)
         {
-            throw std::runtime_error("Failed to parse interactor look-ray AOB pattern");
+            throw std::runtime_error("Interactor look-ray builder cascade did not resolve inside module bounds");
         }
-        const std::byte *lookray = DMK::Scanner::find_pattern(base, module_size, *lookray_pattern);
-        if (!lookray)
-        {
-            throw std::runtime_error("Interactor look-ray builder pattern not found");
-        }
-        s_lookray_lo = reinterpret_cast<uintptr_t>(lookray);
+        s_lookray_lo = lookray;
         s_lookray_hi = s_lookray_lo + Constants::INTERACTOR_LOOKRAY_SPAN;
 
-        // Hook the ray-query builder (sub_180530584).
-        auto build_pattern = DMK::Scanner::parse_aob(Constants::INTERACTION_RAY_BUILD_AOB_PATTERN);
-        if (!build_pattern.has_value())
-        {
-            throw std::runtime_error("Failed to parse interaction ray-build AOB pattern");
-        }
-        const std::byte *build = DMK::Scanner::find_pattern(base, module_size, *build_pattern);
-        if (!build)
-        {
-            throw std::runtime_error("Interaction ray-build pattern not found");
-        }
-        const uintptr_t hook_addr = reinterpret_cast<uintptr_t>(build);
-        if (hook_addr < module_base || hook_addr >= module_end)
+        // Hook the ray-query builder.
+        const uintptr_t hook_addr = resolve_address(Aob::k_interactionRayBuildCandidates, "InteractionRayBuild");
+        if (hook_addr == 0 || hook_addr < module_base || hook_addr >= module_end)
         {
             throw std::runtime_error("Interaction ray-build address resolved outside module bounds");
         }
@@ -345,36 +332,27 @@ bool initialize_interaction_hook(uintptr_t module_base, size_t module_size)
                                      std::string(DMK::Hook::error_to_string(result.error())));
         }
 
-        // Hook the on-screen reticle projection gate (sub_18093C170) -- the gate that drops shrines/
-        // beds/doors when the body is not turned. Non-fatal: failure leaves shrine interaction body-driven.
-        auto onscreen_pattern = DMK::Scanner::parse_aob(Constants::INTERACTION_ONSCREEN_CHECK_AOB_PATTERN);
-        if (onscreen_pattern.has_value())
+        // Hook the on-screen reticle projection gate -- the gate that drops shrines/beds/doors when the
+        // body is not turned. Non-fatal: failure leaves shrine interaction body-driven.
+        const uintptr_t onscreen = resolve_address(Aob::k_interactionOnScreenCandidates, "InteractionOnScreenCheck");
+        if (onscreen != 0 && onscreen >= module_base && onscreen < module_end)
         {
-            const std::byte *onscreen = DMK::Scanner::find_pattern(base, module_size, *onscreen_pattern);
-            if (onscreen != nullptr)
+            auto onscreen_result = DMK::HookManager::get_instance().create_inline_hook(
+                "InteractionOnScreenCheck",
+                onscreen,
+                reinterpret_cast<void *>(on_screen_check_detour),
+                reinterpret_cast<void **>(&s_onscreen_original));
+            if (!onscreen_result.has_value())
             {
-                auto onscreen_result = DMK::HookManager::get_instance().create_inline_hook(
-                    "InteractionOnScreenCheck",
-                    reinterpret_cast<uintptr_t>(onscreen),
-                    reinterpret_cast<void *>(on_screen_check_detour),
-                    reinterpret_cast<void **>(&s_onscreen_original));
-                if (!onscreen_result.has_value())
-                {
-                    logger.warning("InteractionHook[init]: on-screen reticle hook failed ({}); shrine "
-                                   "interaction stays body-driven (look-ray/loot unaffected).",
-                                   std::string(DMK::Hook::error_to_string(onscreen_result.error())));
-                }
-            }
-            else
-            {
-                logger.warning("InteractionHook[init]: on-screen reticle pattern not found; shrine "
-                               "interaction stays body-driven (look-ray/loot unaffected).");
+                logger.warning("InteractionHook[init]: on-screen reticle hook failed ({}); shrine "
+                               "interaction stays body-driven (look-ray/loot unaffected).",
+                               std::string(DMK::Hook::error_to_string(onscreen_result.error())));
             }
         }
         else
         {
-            logger.warning("InteractionHook[init]: failed to parse on-screen reticle AOB; shrine gate "
-                           "disabled.");
+            logger.warning("InteractionHook[init]: on-screen reticle cascade unresolved; shrine "
+                           "interaction stays body-driven (look-ray/loot unaffected).");
         }
 
         return true;

--- a/TPVCamera/src/hooks/player_onaction_hook.cpp
+++ b/TPVCamera/src/hooks/player_onaction_hook.cpp
@@ -4,7 +4,7 @@
  */
 
 #include "hooks/player_onaction_hook.hpp"
-#include "constants.hpp"
+#include "aob_resolver.hpp"
 
 #include <DetourModKit.hpp>
 
@@ -173,9 +173,18 @@ bool initialize_player_onaction_hook(uintptr_t module_base, size_t module_size)
     DMK::Logger &logger = DMK::Logger::get_instance();
     try
     {
+        const uintptr_t dispatch_addr = resolve_address(Aob::k_actionDispatchCandidates, "PlayerOnActionDispatch");
+        const uintptr_t module_end = module_base + module_size;
+        if (dispatch_addr == 0 || dispatch_addr < module_base || dispatch_addr >= module_end)
+        {
+            logger.warning(
+                "PlayerOnAction: action dispatcher cascade unresolved; orbit move-detection uses body speed");
+            return false;
+        }
+
         DMK::HookManager &hook_manager = DMK::HookManager::get_instance();
-        auto result = hook_manager.create_inline_hook_aob(
-            "PlayerOnActionDispatch", module_base, module_size, Constants::ACTION_DISPATCH_AOB_PATTERN, 0,
+        auto result = hook_manager.create_inline_hook(
+            "PlayerOnActionDispatch", dispatch_addr,
             reinterpret_cast<void *>(detour_action_dispatch),
             reinterpret_cast<void **>(&s_action_dispatch_original));
 

--- a/TPVCamera/src/hooks/ui_menu_hooks.cpp
+++ b/TPVCamera/src/hooks/ui_menu_hooks.cpp
@@ -7,7 +7,7 @@
  */
 
 #include "ui_menu_hooks.hpp"
-#include "constants.hpp"
+#include "aob_resolver.hpp"
 
 #include <DetourModKit.hpp>
 
@@ -109,43 +109,16 @@ bool initialize_ui_menu_hooks(uintptr_t module_base, size_t module_size)
 
     try
     {
-        auto open_pattern = DMK::Scanner::parse_aob(Constants::UI_MENU_OPEN_AOB_PATTERN);
-        if (!open_pattern.has_value())
-        {
-            throw std::runtime_error("Failed to parse menu open AOB pattern");
-        }
+        // Each cascade resolves the function entry directly (P1 anchors on the entry; the
+        // mid-body P2/P3 fallbacks walk back to it via their negative disp_offset).
+        const uintptr_t menu_open_addr = resolve_address(Aob::k_menuOpenCandidates, "MenuOpen");
+        const uintptr_t menu_close_addr = resolve_address(Aob::k_menuCloseCandidates, "MenuClose");
 
-        auto close_pattern = DMK::Scanner::parse_aob(Constants::UI_MENU_CLOSE_AOB_PATTERN);
-        if (!close_pattern.has_value())
-        {
-            throw std::runtime_error("Failed to parse menu close AOB pattern");
-        }
-
-        const std::byte *menu_open_hook_address = DMK::Scanner::find_pattern(reinterpret_cast<const std::byte *>(module_base), module_size, *open_pattern);
-        if (!menu_open_hook_address)
-        {
-            throw std::runtime_error("Menu open function pattern not found");
-        }
-
-        const std::byte *menu_close_hook_address = DMK::Scanner::find_pattern(reinterpret_cast<const std::byte *>(module_base), module_size, *close_pattern);
-        if (!menu_close_hook_address)
-        {
-            throw std::runtime_error("Menu close function pattern not found");
-        }
-
-        // The AOB matches an instruction inside each function body; step back a
-        // fixed delta to the real entry point that SafetyHook must patch.
-        //   open:  match is +0x36 into the function (entry sub_180C0B618)
-        //   close: match is +0x18E into the function (entry sub_180C0B260)
-        uintptr_t menu_open_addr = reinterpret_cast<uintptr_t>(menu_open_hook_address) - 0x36;
-        uintptr_t menu_close_addr = reinterpret_cast<uintptr_t>(menu_close_hook_address) - 0x18E;
-
-        // The back-step is only valid if the computed entry still lies inside the
-        // module; a future pattern collision elsewhere could otherwise point the
-        // hook at an unrelated address.
+        // A mid-body fallback could in theory walk back onto a future pattern collision, so
+        // confirm each resolved entry still lies inside the module before hooking it.
         const uintptr_t module_end = module_base + module_size;
-        if (menu_open_addr < module_base || menu_open_addr >= module_end ||
-            menu_close_addr < module_base || menu_close_addr >= module_end)
+        if (menu_open_addr == 0 || menu_open_addr < module_base || menu_open_addr >= module_end ||
+            menu_close_addr == 0 || menu_close_addr < module_base || menu_close_addr >= module_end)
         {
             throw std::runtime_error("Menu function entry point resolved outside module bounds");
         }

--- a/TPVCamera/src/hooks/ui_overlay_hooks.cpp
+++ b/TPVCamera/src/hooks/ui_overlay_hooks.cpp
@@ -10,7 +10,7 @@
  */
 
 #include "ui_overlay_hooks.hpp"
-#include "constants.hpp"
+#include "aob_resolver.hpp"
 #include "global_state.hpp"
 
 #include <DetourModKit.hpp>
@@ -61,13 +61,16 @@ bool initialize_ui_overlay_hooks(uintptr_t module_base, size_t module_size)
     try
     {
         DMK::HookManager &hook_manager = DMK::HookManager::get_instance();
+        const uintptr_t module_end = module_base + module_size;
 
-        auto hide_result = hook_manager.create_inline_hook_aob(
+        const uintptr_t hide_addr = resolve_address(Aob::k_overlayHideCandidates, "HideOverlays");
+        if (hide_addr == 0 || hide_addr < module_base || hide_addr >= module_end)
+        {
+            throw std::runtime_error("HideOverlays cascade did not resolve inside module bounds");
+        }
+        auto hide_result = hook_manager.create_inline_hook(
             "HideOverlays",
-            module_base,
-            module_size,
-            Constants::UI_OVERLAY_HIDE_AOB_PATTERN,
-            0,
+            hide_addr,
             reinterpret_cast<void *>(hide_overlays_detour),
             reinterpret_cast<void **>(&s_hide_overlays_original));
 
@@ -77,12 +80,14 @@ bool initialize_ui_overlay_hooks(uintptr_t module_base, size_t module_size)
                                      std::string(DMK::Hook::error_to_string(hide_result.error())));
         }
 
-        auto show_result = hook_manager.create_inline_hook_aob(
+        const uintptr_t show_addr = resolve_address(Aob::k_overlayShowCandidates, "ShowOverlays");
+        if (show_addr == 0 || show_addr < module_base || show_addr >= module_end)
+        {
+            throw std::runtime_error("ShowOverlays cascade did not resolve inside module bounds");
+        }
+        auto show_result = hook_manager.create_inline_hook(
             "ShowOverlays",
-            module_base,
-            module_size,
-            Constants::UI_OVERLAY_SHOW_AOB_PATTERN,
-            0,
+            show_addr,
             reinterpret_cast<void *>(show_overlays_detour),
             reinterpret_cast<void **>(&s_show_overlays_original));
 

--- a/TPVCamera/src/physics_raycast.cpp
+++ b/TPVCamera/src/physics_raycast.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "physics_raycast.hpp"
+#include "aob_resolver.hpp"
 #include "constants.hpp"
 
 #include <DetourModKit.hpp>
@@ -38,29 +39,23 @@ bool initialize_physics_raycast(uintptr_t module_base, size_t module_size, uintp
 {
     DMK::Logger &logger = DMK::Logger::get_instance();
 
-    const auto pattern = DMK::Scanner::parse_aob(Constants::RAY_WORLD_INTERSECTION_AOB_PATTERN);
-    if (!pattern.has_value())
-    {
-        logger.warning("PhysicsRaycast: failed to parse RayWorldIntersection pattern; collision/aim raycast unavailable");
-        return false;
-    }
-
-    const std::byte *match = DMK::Scanner::find_pattern(
-        reinterpret_cast<const std::byte *>(module_base), module_size, *pattern);
-    if (match == nullptr)
+    // resolve_cascade scans every executable region, so confirm the resolved helper lies inside
+    // the game image before it is called through.
+    const uintptr_t ray_fn = resolve_address(Aob::k_rayWorldIntersectionCandidates, "RayWorldIntersection");
+    if (ray_fn == 0 || ray_fn < module_base || ray_fn >= module_base + module_size)
     {
         logger.warning("PhysicsRaycast: RayWorldIntersection not found (game patched?); collision/aim raycast unavailable");
         return false;
     }
 
-    s_ray_world_intersection = reinterpret_cast<RayWorldIntersectionFn>(reinterpret_cast<uintptr_t>(match));
+    s_ray_world_intersection = reinterpret_cast<RayWorldIntersectionFn>(ray_fn);
     // p_physical_world is a member of the g_env struct (see PHYSICAL_WORLD_OFFSET); deriving its
     // slot from the patch-resiliently resolved g_env base avoids a second hardcoded address.
     s_physical_world_global_addr = g_env + Constants::PHYSICAL_WORLD_OFFSET;
     s_game_module = {module_base, module_base + module_size};
 
     logger.info("PhysicsRaycast: RayWorldIntersection at {}, p_physical_world slot at {}",
-                DMK::Format::format_address(reinterpret_cast<uintptr_t>(match)),
+                DMK::Format::format_address(ray_fn),
                 DMK::Format::format_address(s_physical_world_global_addr));
     return true;
 }


### PR DESCRIPTION
## Summary
Replaces every single-pattern AOB scan with an ordered 3-candidate cascade (`src/aob_resolver.hpp`), so a game patch only has to leave one anchor intact for each hook to keep working.

## Changes
- All hooked functions and read globals now resolve via DetourModKit `resolve_cascade`; single patterns removed from `constants.hpp` and every hook site migrated.
- Each cascade keeps a mid-body anchor that survives a sibling mod inline-hooking the entry; consumers bounds-check the whole-process scan result against the game module.
- Camera-collision rays now hit fabric tent/awning/stall roofs instead of slipping through.
- `HoleDigging` dropped from the default `OrbitExcludeState`.
- README, Nexus BBCode, and changelog updated.

