### PR TITLE
fix(tpvcamera): scope AOB cascade resolution to game module

### DIFF
--- a/TPVCamera/README.md
+++ b/TPVCamera/README.md
@@ -228,10 +228,12 @@ cmake --build --preset msvc-dev
 Game addresses are located patch-resiliently. Every hooked function and read global is found
 through a multi-candidate AOB cascade (`src/aob_resolver.hpp`): each target carries three ordered
 signatures, most-specific first, and the first that resolves wins, so a game patch only has to
-leave one anchor intact for the feature to keep working. At least one candidate per cascade
-anchors past the function prologue, so resolution still succeeds when another mod has inline-hooked
-the entry. The `gEnv` global resolves through the same cascade (with a static RVA fallback), and
-engine object types are matched by their MSVC RTTI names rather than hardcoded vtable addresses.
+leave one anchor intact for the feature to keep working. The cascade is scanned only inside the
+`WHGame.dll` image, so a signature that happens to also appear in another injected mod or graphics
+overlay can never be mistaken for the game's. At least one candidate per cascade anchors past the
+function prologue, so resolution still succeeds when another mod has inline-hooked the entry. The
+`gEnv` global resolves through the same cascade (with a static RVA fallback), and engine object
+types are matched by their MSVC RTTI names rather than hardcoded vtable addresses.
 The cascade signatures follow DetourModKit's
 [AOB signature guide](https://github.com/tkhquang/DetourModKit/blob/main/docs/misc/aob-signatures.md).
 

--- a/TPVCamera/docs/NEXT_CHANGELOG.md
+++ b/TPVCamera/docs/NEXT_CHANGELOG.md
@@ -1,5 +1,3 @@
-## [Title for next release]
+## Fixes and Improvements
 
-- New feature
-- Bug fix
-- Improvement
+- Fixed a startup issue that could stop the third-person camera from loading when other mods or graphics overlays were running

--- a/TPVCamera/src/aob_resolver.hpp
+++ b/TPVCamera/src/aob_resolver.hpp
@@ -5,19 +5,29 @@
  * Every memory location the mod hooks or reads is located by a cascade of
  * ordered AOB candidates rather than a single signature, so a game patch that
  * shifts code only has to leave ONE of three anchors intact for the feature to
- * keep working. Resolution is delegated to DetourModKit's cascading scanner
- * (DMK::Scanner::resolve_cascade); resolve_address() flattens its
- * std::expected return into the uintptr_t-or-zero shape the call sites use.
+ * keep working. Resolution is delegated to DetourModKit's module-scoped cascade
+ * scanner (DMK::Scanner::resolve_cascade_in_module, DMK 3.5.0+): the search is
+ * confined to the WHGame.dll image the caller passes as module_base/module_size,
+ * NOT the whole process. This is deliberate. WHGame.dll is a normal unpacked PE
+ * with every target inside it, so a whole-process scan (resolve_cascade /
+ * scan_executable_regions) buys nothing and is actively unsafe -- a generic
+ * prologue/epilogue candidate can false-match inside another injected module (a
+ * graphics overlay, a sibling mod) and, because the cascade is first-match-wins,
+ * shadow the correct in-module match, disabling the feature or hooking an
+ * unrelated site. resolve_address() flattens the std::expected return into the
+ * uintptr_t-or-zero shape the call sites use.
  *
  * Candidate ordering is most-specific first (P1), so a tight anchor wins before
  * a looser fallback. Each cascade carries at least one candidate anchored PAST
  * the 5-byte function prologue (a negative disp_offset that walks back to the
  * entry); that mid-body anchor still matches when a sibling mod has inline-hooked
- * the entry, because it never reads the overwritten bytes. For that reason, and
- * because these targets may be reshaped by a future game patch (not merely
- * inline-hooked), the resolver uses the STRICT resolve_cascade and NOT the
- * prologue-rewrite fallback: a full miss is a clean failure, never a guess at an
- * unrelated near-JMP site (see external DMK docs/misc/aob-signatures.md section 6.4).
+ * the entry, because the overwritten prologue makes the earlier candidates miss
+ * and the scan falls through to it. Every candidate keeps the DMK default
+ * require_unique=true: a pattern matching more than once inside the image is
+ * skipped as ambiguous (every candidate below is verified to match exactly once
+ * over the full WHGame.dll image), so a freak collision falls through to the next
+ * candidate rather than resolving blindly. A full cascade miss is a clean failure
+ * (0), never a guess at an unrelated near-JMP site.
  *
  * Resolution shapes (DMK::Scanner::ResolveMode):
  *   - Direct      address = match + disp_offset. Entry-hook targets resolve to the
@@ -50,20 +60,21 @@ namespace TPVCamera
     {
         /**
          * @brief Resolve the first matching candidate of a cascade to an absolute
-         *        address, or 0 on total failure.
-         * @details The cascade already logs the winning candidate on success; on
-         *          failure this emits a single Warning so call sites can stay
-         *          focused on conditional feature wiring. Uses the strict
-         *          resolve_cascade (no prologue-rewrite fallback) so a full miss
-         *          is reported as a hard failure rather than a guess at an
-         *          unrelated near-JMP. Resolution still works through a
-         *          sibling-hooked prologue via the mid-body candidates each
-         *          cascade carries.
+         *        address inside the game module, or 0 on total failure.
+         * @details Delegates to DMK::Scanner::resolve_cascade_in_module, which
+         *          scans only [module_base, module_base + module_size) and rejects
+         *          any candidate that resolves outside it, so a bad candidate falls
+         *          through to the next rather than being returned. The cascade logs
+         *          the winning candidate on success; on failure this emits a single
+         *          Warning so call sites can stay focused on conditional feature
+         *          wiring.
          */
         [[nodiscard]] inline std::uintptr_t resolve_cascade_or_zero(
-            std::span<const AddrCandidate> candidates, std::string_view label)
+            std::span<const AddrCandidate> candidates, std::string_view label,
+            std::uintptr_t module_base, std::size_t module_size)
         {
-            const auto hit = DMK::Scanner::resolve_cascade(candidates, label);
+            const DMK::Memory::ModuleRange range{module_base, module_base + module_size};
+            const auto hit = DMK::Scanner::resolve_cascade_in_module(candidates, label, range);
             if (hit.has_value())
             {
                 return hit->address;
@@ -77,14 +88,16 @@ namespace TPVCamera
     } // namespace detail
 
     /**
-     * @brief Resolve a candidate cascade to an absolute address, or 0 on failure.
+     * @brief Resolve a candidate cascade to an absolute address inside the game
+     *        module (module_base/module_size), or 0 on failure.
      */
     template <std::size_t N>
     [[nodiscard]] inline std::uintptr_t resolve_address(
-        const AddrCandidate (&candidates)[N], std::string_view label)
+        const AddrCandidate (&candidates)[N], std::string_view label,
+        std::uintptr_t module_base, std::size_t module_size)
     {
         return detail::resolve_cascade_or_zero(
-            std::span<const AddrCandidate>{candidates, N}, label);
+            std::span<const AddrCandidate>{candidates, N}, label, module_base, module_size);
     }
 
     namespace Aob

--- a/TPVCamera/src/game_interface.cpp
+++ b/TPVCamera/src/game_interface.cpp
@@ -29,18 +29,12 @@ bool initialize_game_interface(uintptr_t module_base, size_t module_size)
         logger.info("GameInterface: Initializing with dynamic AOB scanning...");
 
         // The cascade's RipRelative candidates each resolve the same global-context storage slot
-        // (the RIP-relative MOV/load target), so the returned address is the slot directly.
-        const uintptr_t ctx_slot = resolve_address(Aob::k_contextCandidates, "GlobalContextPtr");
+        // (the RIP-relative MOV/load target), so the returned address is the slot directly. The
+        // module-scoped resolver guarantees the slot lies inside the game image or returns 0.
+        const uintptr_t ctx_slot = resolve_address(Aob::k_contextCandidates, "GlobalContextPtr", module_base, module_size);
         if (ctx_slot == 0)
         {
             throw std::runtime_error("Context pointer cascade did not resolve");
-        }
-
-        // The storage slot lives in the game image; reject a resolution that lands outside it.
-        const uintptr_t module_end = module_base + module_size;
-        if (ctx_slot < module_base || ctx_slot >= module_end)
-        {
-            throw std::runtime_error("Context pointer storage resolved outside module bounds");
         }
 
         g_global_context_ptr_address = reinterpret_cast<std::byte *>(ctx_slot);

--- a/TPVCamera/src/hooks/camera_hook.cpp
+++ b/TPVCamera/src/hooks/camera_hook.cpp
@@ -1916,13 +1916,13 @@ static void __fastcall detour_input_dispatch(uintptr_t controller, uintptr_t inp
  *          result is screened as a plausible user-space pointer before it is accepted.
  * @return The g_env base address (cascade result, or the static fallback).
  */
-static uintptr_t resolve_genv(uintptr_t module_base)
+static uintptr_t resolve_genv(uintptr_t module_base, size_t module_size)
 {
     DMK::Logger &logger = DMK::Logger::get_instance();
 
     // The cascade's RipRelative candidates each resolve the g_env base from a different
     // lea/mov [rip+g_env] reference site; the result is screened as a plausible pointer.
-    const uintptr_t resolved = resolve_address(Aob::k_genvCandidates, "Genv");
+    const uintptr_t resolved = resolve_address(Aob::k_genvCandidates, "Genv", module_base, module_size);
     if (resolved != 0 && DMK::Memory::plausible_userspace_ptr(resolved))
     {
         logger.info("Camera: g_env resolved via AOB at {}", DMK::Format::format_address(resolved));
@@ -1948,7 +1948,7 @@ bool initialize_camera(uintptr_t module_base, size_t module_size)
 
     // Resolve g_env once (patch-resilient AOB, static RVA fallback). The CView vtable is
     // identified lazily by RTTI on the first game-view camera, so nothing is resolved here.
-    s_genv_runtime = resolve_genv(module_base);
+    s_genv_runtime = resolve_genv(module_base, module_size);
 
     // Resolve the engine ray helper for collision + aim convergence. Best-effort: on a miss
     // those features no-op (the camera still renders), so the result is intentionally discarded.
@@ -1958,17 +1958,13 @@ bool initialize_camera(uintptr_t module_base, size_t module_size)
     {
         DMK::HookManager &hook_manager = DMK::HookManager::get_instance();
 
-        // resolve_cascade scans every executable region, not just this module, so each resolved
-        // entry is screened against the game image bounds before it is hooked (a mid-body
-        // walk-back candidate could otherwise land an entry on a future cross-module collision).
-        const uintptr_t module_end = module_base + module_size;
-
         // Hook the camera frustum builder -- the matrix-offset point; without it the feature
-        // does nothing. Resolved by the frustum cascade to the function entry.
-        const uintptr_t frustum_addr = resolve_address(Aob::k_frustumCandidates, "CameraFrustumBuild");
-        if (frustum_addr == 0 || frustum_addr < module_base || frustum_addr >= module_end)
+        // does nothing. The module-scoped cascade resolves to the function entry inside the game
+        // image or returns 0, so no separate bounds check is needed here.
+        const uintptr_t frustum_addr = resolve_address(Aob::k_frustumCandidates, "CameraFrustumBuild", module_base, module_size);
+        if (frustum_addr == 0)
         {
-            throw std::runtime_error("Failed to resolve frustum builder cascade inside module bounds");
+            throw std::runtime_error("Failed to resolve frustum builder cascade");
         }
         auto frustum_result = hook_manager.create_inline_hook(
             "CameraFrustumBuild",
@@ -1984,8 +1980,8 @@ bool initialize_camera(uintptr_t module_base, size_t module_size)
 
         // The head-visibility hook is best-effort: if it fails the camera still works,
         // the player just appears headless from behind, so a miss is a warning.
-        const uintptr_t head_addr = resolve_address(Aob::k_headVisibilityCandidates, "SetHeadVisibility");
-        if (head_addr == 0 || head_addr < module_base || head_addr >= module_end)
+        const uintptr_t head_addr = resolve_address(Aob::k_headVisibilityCandidates, "SetHeadVisibility", module_base, module_size);
+        if (head_addr == 0)
         {
             logger.warning("Camera: Head visibility cascade unresolved; player may appear headless from behind");
         }
@@ -2007,8 +2003,8 @@ bool initialize_camera(uintptr_t module_base, size_t module_size)
         // The input-dispatcher hook powers free-look orbit. Best-effort: a miss only
         // disables orbit, the offset camera still works. The detour is inert until the
         // orbit key is held, so it is harmless when free-look is unused.
-        const uintptr_t input_addr = resolve_address(Aob::k_inputDispatchCandidates, "CameraInputDispatch");
-        if (input_addr == 0 || input_addr < module_base || input_addr >= module_end)
+        const uintptr_t input_addr = resolve_address(Aob::k_inputDispatchCandidates, "CameraInputDispatch", module_base, module_size);
+        if (input_addr == 0)
         {
             logger.warning("Camera: Input dispatcher cascade unresolved; free-look orbit unavailable");
         }

--- a/TPVCamera/src/hooks/interaction_hook.cpp
+++ b/TPVCamera/src/hooks/interaction_hook.cpp
@@ -301,24 +301,22 @@ bool initialize_interaction_hook(uintptr_t module_base, size_t module_size)
 
     try
     {
-        const uintptr_t module_end = module_base + module_size;
-
-        // Resolve the interactor look-ray builder entry -> the caller-range filter bound.
-        // resolve_cascade scans every executable region, so confirm the resolved entry lies inside
-        // the game image: an out-of-module collision would yield a bogus return-address range.
-        const uintptr_t lookray = resolve_address(Aob::k_interactorLookRayCandidates, "InteractorLookRay");
-        if (lookray == 0 || lookray < module_base || lookray >= module_end)
+        // Resolve the interactor look-ray builder entry -> the caller-range filter bound. The
+        // module-scoped cascade keeps the resolved entry inside the game image or returns 0, so a
+        // cross-module collision can no longer yield a bogus return-address range.
+        const uintptr_t lookray = resolve_address(Aob::k_interactorLookRayCandidates, "InteractorLookRay", module_base, module_size);
+        if (lookray == 0)
         {
-            throw std::runtime_error("Interactor look-ray builder cascade did not resolve inside module bounds");
+            throw std::runtime_error("Interactor look-ray builder cascade did not resolve");
         }
         s_lookray_lo = lookray;
         s_lookray_hi = s_lookray_lo + Constants::INTERACTOR_LOOKRAY_SPAN;
 
         // Hook the ray-query builder.
-        const uintptr_t hook_addr = resolve_address(Aob::k_interactionRayBuildCandidates, "InteractionRayBuild");
-        if (hook_addr == 0 || hook_addr < module_base || hook_addr >= module_end)
+        const uintptr_t hook_addr = resolve_address(Aob::k_interactionRayBuildCandidates, "InteractionRayBuild", module_base, module_size);
+        if (hook_addr == 0)
         {
-            throw std::runtime_error("Interaction ray-build address resolved outside module bounds");
+            throw std::runtime_error("Interaction ray-build cascade did not resolve");
         }
 
         auto result = DMK::HookManager::get_instance().create_inline_hook(
@@ -334,8 +332,8 @@ bool initialize_interaction_hook(uintptr_t module_base, size_t module_size)
 
         // Hook the on-screen reticle projection gate -- the gate that drops shrines/beds/doors when the
         // body is not turned. Non-fatal: failure leaves shrine interaction body-driven.
-        const uintptr_t onscreen = resolve_address(Aob::k_interactionOnScreenCandidates, "InteractionOnScreenCheck");
-        if (onscreen != 0 && onscreen >= module_base && onscreen < module_end)
+        const uintptr_t onscreen = resolve_address(Aob::k_interactionOnScreenCandidates, "InteractionOnScreenCheck", module_base, module_size);
+        if (onscreen != 0)
         {
             auto onscreen_result = DMK::HookManager::get_instance().create_inline_hook(
                 "InteractionOnScreenCheck",

--- a/TPVCamera/src/hooks/player_onaction_hook.cpp
+++ b/TPVCamera/src/hooks/player_onaction_hook.cpp
@@ -173,9 +173,8 @@ bool initialize_player_onaction_hook(uintptr_t module_base, size_t module_size)
     DMK::Logger &logger = DMK::Logger::get_instance();
     try
     {
-        const uintptr_t dispatch_addr = resolve_address(Aob::k_actionDispatchCandidates, "PlayerOnActionDispatch");
-        const uintptr_t module_end = module_base + module_size;
-        if (dispatch_addr == 0 || dispatch_addr < module_base || dispatch_addr >= module_end)
+        const uintptr_t dispatch_addr = resolve_address(Aob::k_actionDispatchCandidates, "PlayerOnActionDispatch", module_base, module_size);
+        if (dispatch_addr == 0)
         {
             logger.warning(
                 "PlayerOnAction: action dispatcher cascade unresolved; orbit move-detection uses body speed");

--- a/TPVCamera/src/hooks/ui_menu_hooks.cpp
+++ b/TPVCamera/src/hooks/ui_menu_hooks.cpp
@@ -110,17 +110,13 @@ bool initialize_ui_menu_hooks(uintptr_t module_base, size_t module_size)
     try
     {
         // Each cascade resolves the function entry directly (P1 anchors on the entry; the
-        // mid-body P2/P3 fallbacks walk back to it via their negative disp_offset).
-        const uintptr_t menu_open_addr = resolve_address(Aob::k_menuOpenCandidates, "MenuOpen");
-        const uintptr_t menu_close_addr = resolve_address(Aob::k_menuCloseCandidates, "MenuClose");
-
-        // A mid-body fallback could in theory walk back onto a future pattern collision, so
-        // confirm each resolved entry still lies inside the module before hooking it.
-        const uintptr_t module_end = module_base + module_size;
-        if (menu_open_addr == 0 || menu_open_addr < module_base || menu_open_addr >= module_end ||
-            menu_close_addr == 0 || menu_close_addr < module_base || menu_close_addr >= module_end)
+        // mid-body P2/P3 fallbacks walk back to it via their negative disp_offset). The
+        // module-scoped resolver keeps each entry inside the game image or returns 0.
+        const uintptr_t menu_open_addr = resolve_address(Aob::k_menuOpenCandidates, "MenuOpen", module_base, module_size);
+        const uintptr_t menu_close_addr = resolve_address(Aob::k_menuCloseCandidates, "MenuClose", module_base, module_size);
+        if (menu_open_addr == 0 || menu_close_addr == 0)
         {
-            throw std::runtime_error("Menu function entry point resolved outside module bounds");
+            throw std::runtime_error("Menu function entry cascade did not resolve");
         }
 
         DMK::HookManager &hook_manager = DMK::HookManager::get_instance();

--- a/TPVCamera/src/hooks/ui_overlay_hooks.cpp
+++ b/TPVCamera/src/hooks/ui_overlay_hooks.cpp
@@ -61,12 +61,11 @@ bool initialize_ui_overlay_hooks(uintptr_t module_base, size_t module_size)
     try
     {
         DMK::HookManager &hook_manager = DMK::HookManager::get_instance();
-        const uintptr_t module_end = module_base + module_size;
 
-        const uintptr_t hide_addr = resolve_address(Aob::k_overlayHideCandidates, "HideOverlays");
-        if (hide_addr == 0 || hide_addr < module_base || hide_addr >= module_end)
+        const uintptr_t hide_addr = resolve_address(Aob::k_overlayHideCandidates, "HideOverlays", module_base, module_size);
+        if (hide_addr == 0)
         {
-            throw std::runtime_error("HideOverlays cascade did not resolve inside module bounds");
+            throw std::runtime_error("HideOverlays cascade did not resolve");
         }
         auto hide_result = hook_manager.create_inline_hook(
             "HideOverlays",
@@ -80,10 +79,10 @@ bool initialize_ui_overlay_hooks(uintptr_t module_base, size_t module_size)
                                      std::string(DMK::Hook::error_to_string(hide_result.error())));
         }
 
-        const uintptr_t show_addr = resolve_address(Aob::k_overlayShowCandidates, "ShowOverlays");
-        if (show_addr == 0 || show_addr < module_base || show_addr >= module_end)
+        const uintptr_t show_addr = resolve_address(Aob::k_overlayShowCandidates, "ShowOverlays", module_base, module_size);
+        if (show_addr == 0)
         {
-            throw std::runtime_error("ShowOverlays cascade did not resolve inside module bounds");
+            throw std::runtime_error("ShowOverlays cascade did not resolve");
         }
         auto show_result = hook_manager.create_inline_hook(
             "ShowOverlays",

--- a/TPVCamera/src/physics_raycast.cpp
+++ b/TPVCamera/src/physics_raycast.cpp
@@ -39,10 +39,9 @@ bool initialize_physics_raycast(uintptr_t module_base, size_t module_size, uintp
 {
     DMK::Logger &logger = DMK::Logger::get_instance();
 
-    // resolve_cascade scans every executable region, so confirm the resolved helper lies inside
-    // the game image before it is called through.
-    const uintptr_t ray_fn = resolve_address(Aob::k_rayWorldIntersectionCandidates, "RayWorldIntersection");
-    if (ray_fn == 0 || ray_fn < module_base || ray_fn >= module_base + module_size)
+    // The module-scoped cascade resolves the helper inside the game image or returns 0.
+    const uintptr_t ray_fn = resolve_address(Aob::k_rayWorldIntersectionCandidates, "RayWorldIntersection", module_base, module_size);
+    if (ray_fn == 0)
     {
         logger.warning("PhysicsRaycast: RayWorldIntersection not found (game patched?); collision/aim raycast unavailable");
         return false;


### PR DESCRIPTION
## Summary
Confine all AOB cascade resolution to the `WHGame.dll` image so signatures in other injected modules can't false-match and stop the third-person camera from loading.

## What changed
- Resolve cascades via DetourModKit 3.5.0's module-scoped `resolve_cascade_in_module`.
- Removed the now-redundant per-call-site bounds checks.
- Bumped DetourModKit submodule; version -> 1.0.3.

## Why
First-match-wins meant a generic signature in an overlay/sibling mod could shadow the correct in-module hit. Module scoping makes a full miss a clean failure.

