### PR TITLE
fix(tpvcamera): stop controller zoom from opening inventory/map

### DIFF
--- a/TPVCamera/README.md
+++ b/TPVCamera/README.md
@@ -63,6 +63,11 @@ Free-look orbit has two styles: `OrbitToggleKey` (default `F4`) latches it on an
 `OrbitHoldKey` (unbound by default) is a momentary "freelook" you hold to look around and release
 to snap straight back to the aim camera. Bind `OrbitHoldKey` in the INI to use it.
 
+On a controller the zoom shares the D-pad with the game's inventory/map shortcut, so the mod hides
+that D-pad button from the game while you zoom (the `ZoomInKey.Consume` / `ZoomOutKey.Consume` keys,
+on by default) so finishing a zoom does not open the inventory or map. Set them to `false` if you
+would rather the D-pad keep reaching the game. The keyboard zoom keys are unaffected.
+
 ## How It Works
 
 The camera hooks the engine's frustum builder and offsets the game view camera's matrix there,

--- a/TPVCamera/build/template/KCD2_TPVCamera.ini
+++ b/TPVCamera/build/template/KCD2_TPVCamera.ini
@@ -50,11 +50,17 @@ AutoEnableOrbit = false
 ; KCD2_TPVCamera_presets.json next to this file. Only the always-on options
 ; below remain in the INI.
 
-; ZoomInKey / ZoomOutKey hold to pull the camera closer / push it farther
-; (within the active preset's zoom range).
-; Default: LShift+PageUp / LShift+PageDown, or hold LB + D-pad up/down on a controller.
+; ZoomInKey / ZoomOutKey hold to pull the camera closer / push it farther (within the active preset's
+; zoom range). Default: LShift+PageUp / LShift+PageDown, or hold LB + D-pad up/down on a controller.
+;
+; The matching <key>.Consume hides the controller D-pad button used for that zoom direction from the
+; game while the combo is held, so adjusting the zoom on a controller does not also open the
+; inventory/map when you finish. Only the gamepad D-pad is affected; the LB modifier and the keyboard
+; zoom keys still reach the game. Default: true (set false to let the D-pad reach the game as usual).
 ZoomInKey = LShift+PageUp,Gamepad_LB+Gamepad_DpadUp
+ZoomInKey.Consume = true
 ZoomOutKey = LShift+PageDown,Gamepad_LB+Gamepad_DpadDown
+ZoomOutKey.Consume = true
 
 ; InteractFromCamera makes the game's "look at / press to use" target follow the
 ; SCREEN CENTRE in third person. Normally KCD2 picks what to use by casting from

--- a/TPVCamera/docs/NEXT_CHANGELOG.md
+++ b/TPVCamera/docs/NEXT_CHANGELOG.md
@@ -1,5 +1,4 @@
 ## [Title for next release]
 
-- New feature
-- Bug fix
-- Improvement
+- Fixed the controller zoom (hold LB + D-pad up/down) sometimes opening the inventory or map when you finish zooming
+- Updated the bundled modding toolkit to the latest version

--- a/TPVCamera/docs/nexus-bbcode.txt
+++ b/TPVCamera/docs/nexus-bbcode.txt
@@ -57,6 +57,7 @@ All keys are rebindable in KCD2_TPVCamera.ini.
 [*][b]Zoom out:[/b] LShift + PageDown, or hold LB + D-pad down[/*]
 [*][b]Force first-person / force third-person:[/b] unbound by default[/*]
 [/list]
+On a controller the zoom shares the D-pad with the game's inventory/map shortcut, so the mod hides that D-pad button from the game while you zoom (the ZoomInKey.Consume / ZoomOutKey.Consume keys, on by default) so finishing a zoom does not open the inventory or map. Set them to false if you would rather the D-pad keep reaching the game. The keyboard zoom keys are unaffected.
 
 [size=5]Configuration[/size]
 Edit KCD2_TPVCamera.ini, grouped into:

--- a/TPVCamera/src/tpv_camera.cpp
+++ b/TPVCamera/src/tpv_camera.cpp
@@ -245,18 +245,30 @@ static void register_press_bindings()
 }
 
 /**
- * @brief Registers the hold bindings after the INI key lists have been loaded.
- * @details DMK has no hold-combo helper, so the INI keys are parsed by register_config_items and
- *          the InputManager hold bindings are created here from the resulting lists. The zoom
- *          callbacks are empty -- the frustum-builder detour queries their hold state by name each
- *          frame to drive the follow distance. The orbit-hold callback instead engages/releases
- *          free-look directly on its key edges (momentary freelook), so nothing polls it per frame.
+ * @brief Registers the hold bindings (and the zoom triggers' optional INI consume flags) before load().
+ * @details DMK has no hold-combo helper, so the holds are created here from g_config (seeded with the
+ *          default combos by register_config_items); DMK::Config::load() then applies the INI combos
+ *          via update_binding_combos, the same way the press combos rebind on load. The zoom callbacks
+ *          are empty -- the frustum-builder detour queries their hold state by name each frame to drive
+ *          the follow distance. The orbit-hold callback instead engages/releases free-look directly on
+ *          its key edges (momentary freelook), so nothing polls it per frame.
  */
 static void register_hold_bindings()
 {
     DMK::InputManager &input_mgr = DMK::InputManager::get_instance();
     input_mgr.register_hold(k_zoom_in_binding, g_config.zoom_in_keys, [](bool) {});
     input_mgr.register_hold(k_zoom_out_binding, g_config.zoom_out_keys, [](bool) {});
+
+    // Passthrough suppression for the gamepad zoom triggers, on by default and toggled per binding from
+    // the INI (ZoomInKey.Consume / ZoomOutKey.Consume). While enabled, DMK masks just the bound D-pad
+    // button out of the XInput state the game reads, so the LB + D-pad up/down zoom combo does not also
+    // fire the game's inventory/map shortcut as the gesture ends. Only the trigger button is masked
+    // (never the LB modifier, and keyboard zoom is never affected), and the mask is latched to the
+    // physical D-pad release plus a short grace window, so releasing LB a frame early cannot leak a
+    // bare D-pad press. Registered after the holds they target and before DMK::Config::load(), so the
+    // INI value lands on an existing binding at load and on every reload.
+    DMK::Config::register_consume_flag("Camera", "ZoomInKey.Consume", "Zoom In Consume", k_zoom_in_binding, true);
+    DMK::Config::register_consume_flag("Camera", "ZoomOutKey.Consume", "Zoom Out Consume", k_zoom_out_binding, true);
 
     // Momentary free-look (freelook, as in ArmA / DayZ / PUBG): hold OrbitHoldKey to engage the
     // orbit and release to return to the precise camera-aim view. register_hold fires the callback
@@ -317,9 +329,13 @@ bool init()
     logger.info("----------------------------------------");
     Version::log_version_info();
 
-    // Register every config item and the press bindings, then load and log once.
+    // Register every config item, then the press and hold bindings, then load and log once. The
+    // bindings are all registered before load() so the INI key combos (and the optional consume flags
+    // on the gamepad zoom triggers) apply to them during load, exactly as the press combos rebind on
+    // load.
     register_config_items();
     register_press_bindings();
+    register_hold_bindings();
     DMK::Config::load(Constants::get_config_filename());
     DMK::Config::log_all();
 
@@ -345,8 +361,6 @@ bool init()
     if (!initialize_hooks())
         return false;
 
-    // Hold bindings need the loaded key lists; register them before starting the poll.
-    register_hold_bindings();
     DMK::InputManager::get_instance().start();
     logger.info("InputManager started");
 


### PR DESCRIPTION
## Summary
On a controller, the zoom combo (hold `LB` + D-pad up/down) shares the D-pad with the game's inventory/map shortcut, so finishing a zoom could also open the inventory or map. The mod now hides that D-pad button from the game while you zoom.

## Changes
- New INI keys `ZoomInKey.Consume` / `ZoomOutKey.Consume` (default `true`; set `false` to let the D-pad reach the game). Keyboard zoom is unaffected.
- Register zoom holds and consume flags before `Config::load()` so INI values apply on load and reload.
- Bump bundled DetourModKit to v3.6.1 (`84ec4b8`).
- Update README, INI template, nexus-bbcode, and changelog.
