### PR TITLE
feat(tpvcamera): add GOG version support

### DIFF
--- a/TPVCamera/README.md
+++ b/TPVCamera/README.md
@@ -29,8 +29,10 @@ start in first-person instead.
 1. If you previously installed the older **KCD2_TPVToggle** mod, remove it first: delete
    `KCD2_TPVToggle.asi` and `KCD2_TPVToggle.ini` from the game's binary folder. TPVCamera replaces it,
    and running both third-person camera mods at once will conflict.
-2. Extract all files into your game's binary folder:
-   `<KC:D 2 installation folder>/Bin/Win64MasterMasterSteamPGO/`
+2. Extract all files into your game's binary folder (the `Bin/Win64MasterMaster...` subfolder that contains
+   `WHGame.dll`). On Steam this is
+   `<KC:D 2 installation folder>/Bin/Win64MasterMasterSteamPGO/`; the GOG version uses its own
+   `Bin/Win64MasterMaster...` folder.
 3. Launch the game; third-person turns on automatically once you reach gameplay.
 4. Press `F3` (default), or hold `LB + RB` on a controller, to toggle back to first-person.
 
@@ -236,7 +238,7 @@ cmake --build --preset msvc-dev
   and the mod lifecycle
 
 Game addresses are located patch-resiliently. Every hooked function and read global is found
-through a multi-candidate AOB cascade (`src/aob_resolver.hpp`): each target carries three ordered
+through a multi-candidate AOB cascade (`src/aob_resolver.hpp`): each target carries several ordered
 signatures, most-specific first, and the first that resolves wins, so a game patch only has to
 leave one anchor intact for the feature to keep working. The cascade is scanned only inside the
 `WHGame.dll` image, so a signature that happens to also appear in another injected mod or graphics

--- a/TPVCamera/docs/NEXT_CHANGELOG.md
+++ b/TPVCamera/docs/NEXT_CHANGELOG.md
@@ -1,4 +1,6 @@
-## [Title for next release]
+## GOG Support and Fixes
 
 - Fixed the controller zoom (hold LB + D-pad up/down) sometimes opening the inventory or map when you finish zooming
 - Updated the bundled modding toolkit to the latest version
+- Added support for the GOG version of the game
+- Made the camera zoom in and out in bigger steps so it moves faster per press

--- a/TPVCamera/docs/nexus-bbcode.txt
+++ b/TPVCamera/docs/nexus-bbcode.txt
@@ -27,12 +27,12 @@ Third-person turns on automatically once you reach gameplay; press the toggle ke
 
 [size=5]Requirements[/size]
 [list]
-[*]Kingdom Come: Deliverance II (Steam version)[/*]
+[*]Kingdom Come: Deliverance II (Steam or GOG version)[/*]
 [/list]
 
 [size=5]Installation[/size]
 1. If you have the older [url=https://www.nexusmods.com/kingdomcomedeliverance2/mods/1550]KCD2_TPVToggle[/url] mod installed, remove it first: delete KCD2_TPVToggle.asi and KCD2_TPVToggle.ini from your game directory. TPVCamera replaces it, and running both third-person camera mods at once will conflict.
-2. Extract all files from the archive to your game directory:
+2. Extract all files from the archive to your game's binary folder, the Bin/Win64MasterMaster... subfolder that contains WHGame.dll. On Steam that is:
  
 [code]<KC:D 2 installation folder>/Bin/Win64MasterMasterSteamPGO/[/code]
 3. Launch the game; third-person turns on automatically. Press F3 (or hold LB + RB) to toggle back to first-person

--- a/TPVCamera/src/aob_resolver.hpp
+++ b/TPVCamera/src/aob_resolver.hpp
@@ -351,20 +351,35 @@ namespace TPVCamera
         };
 
         // --- UI menu-close entry (vftable[2]) -------------------------------
-        // Direct entry hook. P1 anchors on the entry prologue through the
-        // `cmp byte [rsi+0A0h], 0` field test. P2 is the mid-body anchor on the
-        // deactivate store (`mov byte [rbx+49h], 0; call;
-        // mov byte [rbx+48h], 0`) with the register ModRM bytes wildcarded so it
-        // matches whether the object is held in rbx or rdi; it walks back 0x18E.
-        // P3 anchors on the field-test branch and walks back 0x0F.
+        // Direct entry hook. The object pointer (this - 0x58) lives in a
+        // compiler-allocated register that differs across build configs, which
+        // also shifts the prologue length: the Steam build uses rsi and saves it
+        // with an extra `mov [rsp+20h], rsi` (5 bytes) before `push rdi`, while
+        // the GOG build uses rdi and saves only `push rdi`. That changes both the
+        // prologue LENGTH and the ModRM bytes of `lea r,[rcx-58h]` /
+        // `cmp byte [r+0A0h], 0`, so a single entry pattern cannot span both, and
+        // a single mid-body walk-back distance is build-specific too (the Steam
+        // body is 0x18E entry->store; GOG is 0x15F, so the old -0x18E anchor
+        // landed 0x2F before the GOG entry, inside the previous function). P1 is
+        // the Steam rsi-form entry; P2 is the GOG/alt-register entry (save-one-reg
+        // form) with the lea/cmp register ModRM wildcarded so it tolerates any
+        // object register. Both are disp 0 (entry-anchored, build-robust), so a
+        // GOG match wins before the mis-calibrated walk-backs are reached. P3/P4
+        // are last-resort mid-body anchors (used only if both entry forms miss):
+        // P3 the deactivate store (`mov byte [r+49h], 0; call;
+        // mov byte [r+48h], 0`, register ModRM wildcarded) walking back 0x18E, P4
+        // the field-test branch walking back 0x0F.
         inline constexpr AddrCandidate k_menuCloseCandidates[] = {
-            {"MenuClose_P1_EntryFieldTest",
+            {"MenuClose_P1_EntryFieldTestRsi",
              "48 89 5C 24 18 48 89 74 24 20 57 48 83 EC 30 48 8D 71 A8 48 8B D9 80 BE A0 00 00 00 00",
              ResolveMode::Direct, 0, 0},
-            {"MenuClose_P2_DeactivateStore",
+            {"MenuClose_P2_EntryFieldTestAltReg",
+             "48 89 5C 24 18 57 48 83 EC 30 48 8D ?? A8 48 8B D9 80 ?? A0 00 00 00 00",
+             ResolveMode::Direct, 0, 0},
+            {"MenuClose_P3_DeactivateStore",
              "8A ?? 48 48 8D ?? 28 C6 ?? 49 00 E8 ?? ?? ?? ?? C6 ?? 48 00",
              ResolveMode::Direct, -0x18E, 0},
-            {"MenuClose_P3_FieldTestBranch",
+            {"MenuClose_P4_FieldTestBranch",
              "48 8D 71 A8 48 8B D9 80 BE A0 00 00 00 00 0F 84 ?? ?? ?? ?? E8",
              ResolveMode::Direct, -0x0F, 0},
         };

--- a/TPVCamera/src/presets/default_presets.hpp
+++ b/TPVCamera/src/presets/default_presets.hpp
@@ -59,7 +59,7 @@ inline constexpr const char *k_default_presets_json = R"json(
         "orbit_return_speed": 8.0,
         "orbit_sensitivity": 0.2,
         "orbit_smoothing": 0.5,
-        "zoom_step": 1.0
+        "zoom_step": 4.0
       }
     },
     {
@@ -90,7 +90,7 @@ inline constexpr const char *k_default_presets_json = R"json(
         "orbit_return_speed": 8.0,
         "orbit_sensitivity": 0.2,
         "orbit_smoothing": 0.5,
-        "zoom_step": 1.0
+        "zoom_step": 4.0
       }
     },
     {
@@ -121,7 +121,7 @@ inline constexpr const char *k_default_presets_json = R"json(
         "orbit_return_speed": 8.0,
         "orbit_sensitivity": 0.2,
         "orbit_smoothing": 0.5,
-        "zoom_step": 1.0
+        "zoom_step": 4.0
       }
     },
     {
@@ -152,7 +152,7 @@ inline constexpr const char *k_default_presets_json = R"json(
         "orbit_return_speed": 8.0,
         "orbit_sensitivity": 0.2,
         "orbit_smoothing": 0.5,
-        "zoom_step": 1.0
+        "zoom_step": 4.0
       }
     },
     {
@@ -183,7 +183,7 @@ inline constexpr const char *k_default_presets_json = R"json(
         "orbit_return_speed": 8.0,
         "orbit_sensitivity": 0.2,
         "orbit_smoothing": 0.5,
-        "zoom_step": 1.0
+        "zoom_step": 4.0
       }
     },
     {
@@ -214,7 +214,7 @@ inline constexpr const char *k_default_presets_json = R"json(
         "orbit_return_speed": 8.0,
         "orbit_sensitivity": 0.2,
         "orbit_smoothing": 0.5,
-        "zoom_step": 1.0
+        "zoom_step": 4.0
       }
     },
     {
@@ -245,7 +245,7 @@ inline constexpr const char *k_default_presets_json = R"json(
         "orbit_return_speed": 8.0,
         "orbit_sensitivity": 0.2,
         "orbit_smoothing": 0.5,
-        "zoom_step": 1.0
+        "zoom_step": 4.0
       }
     },
     {
@@ -276,7 +276,7 @@ inline constexpr const char *k_default_presets_json = R"json(
         "orbit_return_speed": 8.0,
         "orbit_sensitivity": 0.2,
         "orbit_smoothing": 0.5,
-        "zoom_step": 1.0
+        "zoom_step": 4.0
       }
     },
     {
@@ -307,7 +307,7 @@ inline constexpr const char *k_default_presets_json = R"json(
         "orbit_return_speed": 8.0,
         "orbit_sensitivity": 0.2,
         "orbit_smoothing": 0.5,
-        "zoom_step": 1.0
+        "zoom_step": 4.0
       }
     }
   ]


### PR DESCRIPTION
## Summary

Verifies TPVCamera against the GOG build of WHGame.dll (1.5.5) and fixes the one hook that mis-resolved, so all 14 AOB cascades land correctly on both Steam and GOG. Also bumps the default zoom step and refreshes the docs.

## Changes

- **GOG menu-close fix** (`src/aob_resolver.hpp`): the menu-close function's object pointer is in `rdi` on GOG vs `rsi` on Steam, so the existing rsi-form entry signatures missed and the `-0x18E` mid-body walk-back (Steam's entry→store distance) landed inside the wrong function on GOG. Added a register-agnostic, entry-anchored candidate so MenuClose resolves to the true entry on both builds; no change to Steam resolution.
- **Larger default zoom step** (`src/presets/default_presets.hpp`): `zoom_step` default raised from `1.0` to `4.0` across all built-in presets (affects fresh installs / regenerated presets only).

## Notes

- The deprecated **TPVToggle** mod has the same latent GOG menu-close miscalibration (single pattern, no cascade fallback) and is left unchanged; can be addressed separately if still supported.
