### PR TITLE
feat(tpvcamera): upgrade to DetourModKit 3.8.0

### DIFF
--- a/TPVCamera/CMakeLists.txt
+++ b/TPVCamera/CMakeLists.txt
@@ -106,6 +106,7 @@ endif()
 
 # --- Source Files ---
 set(COMMON_SOURCES
+  src/aob_resolver.cpp
   src/config.cpp
   src/game_interface.cpp
   src/game_state.cpp
@@ -128,9 +129,11 @@ set(COMMON_SOURCES
 )
 
 # Applies the settings shared by the production ASI and the dev logic DLL: include
-# paths, link libraries, and the Release size/opt flags. /O1 favors size (suited to
-# an injected DLL); /Gy + /Gw with /OPT:REF + /OPT:ICF let the linker drop and fold
-# unused functions and data.
+# paths, link libraries, and the Release speed/opt flags. /O2 favors speed: the
+# overlay renders through a software WARP device with a per-pixel premultiply loop
+# every frame, so the few KB /O1 would save are not worth deoptimizing that path on
+# an .asi where image size is not a real constraint. /Gy + /Gw with /OPT:REF +
+# /OPT:ICF still let the linker drop and fold unused functions and data.
 function(configure_logic_target target)
   target_include_directories(${target} PRIVATE src)
   # imgui_lib brings the ImGui + Win32/DX11 backend include paths transitively.
@@ -139,7 +142,7 @@ function(configure_logic_target target)
   target_link_libraries(${target} PRIVATE
     DetourModKit imgui_lib nlohmann_json::nlohmann_json
     psapi user32 kernel32 d3d11 dxgi gdi32 winmm)
-  target_compile_options(${target} PRIVATE $<$<CONFIG:Release>:/O1 /Gy /Gw>)
+  target_compile_options(${target} PRIVATE $<$<CONFIG:Release>:/O2 /Gy /Gw>)
   target_link_options(${target} PRIVATE $<$<CONFIG:Release>:/OPT:REF /OPT:ICF>)
 endfunction()
 

--- a/TPVCamera/README.md
+++ b/TPVCamera/README.md
@@ -240,13 +240,16 @@ cmake --build --preset msvc-dev
 Game addresses are located patch-resiliently. Every hooked function and read global is found
 through a multi-candidate AOB cascade (`src/aob_resolver.hpp`): each target carries several ordered
 signatures, most-specific first, and the first that resolves wins, so a game patch only has to
-leave one anchor intact for the feature to keep working. The cascade is scanned only inside the
+leave one anchor intact for the feature to keep working. The cascades are declared as a single
+DetourModKit anchor registry (`src/aob_resolver.cpp`) and resolved in one parallel pass at startup,
+which logs a per-anchor status and an overall quality summary. The cascade is scanned only inside the
 `WHGame.dll` image, so a signature that happens to also appear in another injected mod or graphics
 overlay can never be mistaken for the game's. At least one candidate per cascade anchors past the
-function prologue, so resolution still succeeds when another mod has inline-hooked the entry. The
-`gEnv` global resolves through the same cascade (with a static RVA fallback), and engine object
-types are matched by their MSVC RTTI names rather than hardcoded vtable addresses.
-The cascade signatures follow DetourModKit's
+function prologue, so resolution still succeeds when another mod has inline-hooked the entry; the
+hooks themselves install with a fail-closed prologue check so a mis-resolved entry is refused rather
+than patched blindly. The `gEnv` global resolves through the same cascade (with a static RVA
+fallback), and engine object types are matched by their MSVC RTTI names rather than hardcoded vtable
+addresses. The cascade signatures follow DetourModKit's
 [AOB signature guide](https://github.com/tkhquang/DetourModKit/blob/main/docs/misc/aob-signatures.md).
 
 ## Credits

--- a/TPVCamera/docs/NEXT_CHANGELOG.md
+++ b/TPVCamera/docs/NEXT_CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Title for next release]
 
-- New feature
-- Bug fix
-- Improvement
+- Updated the bundled modding toolkit (DetourModKit) to the latest version (v3.8.0)
+- Fixed the preset overlay looking blurry or misaligned on displays scaled above 100%
+- Saved camera presets can no longer be lost if the game closes while they are being written
+- Made the camera more resilient to future game updates and safer to load alongside other mods
+- Various under-the-hood stability and reliability fixes

--- a/TPVCamera/src/aob_resolver.cpp
+++ b/TPVCamera/src/aob_resolver.cpp
@@ -1,0 +1,111 @@
+/**
+ * @file aob_resolver.cpp
+ * @brief Declarative anchor table, one-pass resolution, and the resolved-address store.
+ *
+ * The cascade candidate tables in aob_resolver.hpp are wrapped one-to-one as RipGlobal entries in a
+ * DetourModKit anchor registry. resolve_all_anchors() resolves the whole table in a single parallel
+ * pass at startup and records each address; anchor_address() hands the resolved address (or 0 on a
+ * cascade miss) to the call sites, replacing the previous scattered per-call resolution.
+ */
+
+#include "aob_resolver.hpp"
+
+#include <DetourModKit.hpp>
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <span>
+#include <string_view>
+
+namespace TPVCamera
+{
+namespace
+{
+
+using DMK::Anchors::Anchor;
+using DMK::Anchors::AnchorKind;
+
+constexpr std::size_t k_anchor_count = static_cast<std::size_t>(AnchorId::Count);
+
+/// Builds a RipGlobal anchor over a cascade candidate array (the candidates select Direct vs RIP).
+constexpr Anchor rip_global(std::string_view label, std::span<const AddrCandidate> site) noexcept
+{
+    return Anchor{.label = label, .kind = AnchorKind::RipGlobal, .site = site};
+}
+
+// The declarative anchor table, indexed by AnchorId. Each entry wraps one cascade candidate array from
+// aob_resolver.hpp as a RipGlobal anchor. Anchors::resolve runs the same Scanner::resolve_cascade_in_module
+// the mod used before, and the candidates' own ResolveMode selects Direct (function entry) vs RipRelative
+// (global data slot), so a resolved address is byte-for-byte identical to the previous per-call resolution.
+// The registry only adds one-pass parallel resolution, a unified quality report, and a foundation for
+// validators / fingerprints. Labels match the previous per-cascade log labels for log continuity.
+constexpr std::array<Anchor, k_anchor_count> k_anchor_table = {{
+    rip_global("GlobalContextPtr", Aob::k_contextCandidates),
+    rip_global("Genv", Aob::k_genvCandidates),
+    rip_global("CameraFrustumBuild", Aob::k_frustumCandidates),
+    rip_global("SetHeadVisibility", Aob::k_headVisibilityCandidates),
+    rip_global("CameraInputDispatch", Aob::k_inputDispatchCandidates),
+    rip_global("PlayerOnActionDispatch", Aob::k_actionDispatchCandidates),
+    rip_global("RayWorldIntersection", Aob::k_rayWorldIntersectionCandidates),
+    rip_global("InteractionRayBuild", Aob::k_interactionRayBuildCandidates),
+    rip_global("InteractorLookRay", Aob::k_interactorLookRayCandidates),
+    rip_global("InteractionOnScreenCheck", Aob::k_interactionOnScreenCandidates),
+    rip_global("HideOverlays", Aob::k_overlayHideCandidates),
+    rip_global("ShowOverlays", Aob::k_overlayShowCandidates),
+    rip_global("MenuOpen", Aob::k_menuOpenCandidates),
+    rip_global("MenuClose", Aob::k_menuCloseCandidates),
+}};
+
+// Resolved absolute addresses, indexed by AnchorId; 0 means unresolved. Zero-initialized (constant
+// init, no static-init-order hazard). Written once by resolve_all_anchors() on the init thread before
+// any consumer reads, then read-only, so no synchronization is required.
+std::array<std::uintptr_t, k_anchor_count> s_resolved_addresses{};
+
+} // namespace
+
+void resolve_all_anchors(std::uintptr_t module_base, std::size_t module_size)
+{
+    DMK::Logger &logger = DMK::Logger::get_instance();
+
+    // Confine resolution to the WHGame.dll image. The DMK default host_module_range() is the host EXE,
+    // not WHGame.dll, so the range is passed explicitly.
+    const DMK::Memory::ModuleRange range{module_base, module_base + module_size};
+
+    std::array<DMK::Anchors::ResolvedAnchor, k_anchor_count> report{};
+    const std::size_t resolved_count = DMK::Anchors::resolve_all_parallel(k_anchor_table, report, range);
+
+    // resolve_all_parallel writes report[i] for k_anchor_table[i], so the report index is the AnchorId.
+    for (std::size_t i = 0; i < resolved_count; ++i)
+    {
+        const DMK::Anchors::ResolvedAnchor &entry = report[i];
+        if (entry.status == DMK::Anchors::AnchorStatus::Resolved)
+        {
+            s_resolved_addresses[i] = static_cast<std::uintptr_t>(entry.value);
+            logger.info("Anchor {} -> {}", entry.label, DMK::Format::format_address(s_resolved_addresses[i]));
+        }
+        else
+        {
+            s_resolved_addresses[i] = 0;
+            logger.warning("Anchor {} unresolved ({})", entry.label,
+                           DMK::Anchors::anchor_status_to_string(entry.status));
+        }
+    }
+
+    const DMK::Anchors::AnchorQuality quality =
+        DMK::Anchors::assess_quality(std::span<const DMK::Anchors::ResolvedAnchor>(report.data(), resolved_count));
+    logger.info("Anchor resolution: {}/{} resolved, {} failed, {} unsupported", quality.resolved, quality.total,
+                quality.failed, quality.unsupported);
+}
+
+std::uintptr_t anchor_address(AnchorId id) noexcept
+{
+    const std::size_t index = static_cast<std::size_t>(id);
+    if (index >= k_anchor_count)
+    {
+        return 0;
+    }
+    return s_resolved_addresses[index];
+}
+
+} // namespace TPVCamera

--- a/TPVCamera/src/aob_resolver.hpp
+++ b/TPVCamera/src/aob_resolver.hpp
@@ -1,6 +1,6 @@
 /**
  * @file aob_resolver.hpp
- * @brief Cascading AOB candidate tables and the resolve helper for the mod.
+ * @brief Cascading AOB candidate tables and the declarative anchor registry for the mod.
  *
  * Every memory location the mod hooks or reads is located by a cascade of
  * ordered AOB candidates rather than a single signature, so a game patch that
@@ -14,8 +14,10 @@
  * prologue/epilogue candidate can false-match inside another injected module (a
  * graphics overlay, a sibling mod) and, because the cascade is first-match-wins,
  * shadow the correct in-module match, disabling the feature or hooking an
- * unrelated site. resolve_address() flattens the std::expected return into the
- * uintptr_t-or-zero shape the call sites use.
+ * unrelated site. The cascade tables are wrapped one-to-one as RipGlobal entries
+ * in a declarative DMK::Anchors registry (AnchorId below); resolve_all_anchors()
+ * resolves the whole table in one parallel pass at startup and anchor_address()
+ * returns each resolved address (or 0 on a cascade miss) to the call sites.
  *
  * Candidate ordering is most-specific first (P1), so a tight anchor wins before
  * a looser fallback. Each cascade carries at least one candidate anchored PAST
@@ -48,57 +50,11 @@
 
 #include <cstddef>
 #include <cstdint>
-#include <span>
-#include <string_view>
 
 namespace TPVCamera
 {
     using AddrCandidate = DMK::Scanner::AddrCandidate;
     using ResolveMode = DMK::Scanner::ResolveMode;
-
-    namespace detail
-    {
-        /**
-         * @brief Resolve the first matching candidate of a cascade to an absolute
-         *        address inside the game module, or 0 on total failure.
-         * @details Delegates to DMK::Scanner::resolve_cascade_in_module, which
-         *          scans only [module_base, module_base + module_size) and rejects
-         *          any candidate that resolves outside it, so a bad candidate falls
-         *          through to the next rather than being returned. The cascade logs
-         *          the winning candidate on success; on failure this emits a single
-         *          Warning so call sites can stay focused on conditional feature
-         *          wiring.
-         */
-        [[nodiscard]] inline std::uintptr_t resolve_cascade_or_zero(
-            std::span<const AddrCandidate> candidates, std::string_view label,
-            std::uintptr_t module_base, std::size_t module_size)
-        {
-            const DMK::Memory::ModuleRange range{module_base, module_base + module_size};
-            const auto hit = DMK::Scanner::resolve_cascade_in_module(candidates, label, range);
-            if (hit.has_value())
-            {
-                return hit->address;
-            }
-
-            DMK::Logger::get_instance().warning(
-                "{} resolve cascade failed: {}", label,
-                DMK::Scanner::resolve_error_to_string(hit.error()));
-            return 0;
-        }
-    } // namespace detail
-
-    /**
-     * @brief Resolve a candidate cascade to an absolute address inside the game
-     *        module (module_base/module_size), or 0 on failure.
-     */
-    template <std::size_t N>
-    [[nodiscard]] inline std::uintptr_t resolve_address(
-        const AddrCandidate (&candidates)[N], std::string_view label,
-        std::uintptr_t module_base, std::size_t module_size)
-    {
-        return detail::resolve_cascade_or_zero(
-            std::span<const AddrCandidate>{candidates, N}, label, module_base, module_size);
-    }
 
     namespace Aob
     {
@@ -384,6 +340,51 @@ namespace TPVCamera
              ResolveMode::Direct, -0x0F, 0},
         };
     } // namespace Aob
+
+    /**
+     * @brief Stable identity for every game-image anchor the mod resolves at startup.
+     * @details Indexes both the declarative anchor table resolved once by resolve_all_anchors() and the
+     *          address store read by anchor_address(). The enumerator order IS the table order; Count is
+     *          the element count and is not a valid anchor.
+     */
+    enum class AnchorId : std::size_t
+    {
+        Context,              // global-context storage slot (camera-manager root)
+        Genv,                 // SSystemGlobalEnvironment base
+        Frustum,              // camera frustum builder (mandatory hook target)
+        HeadVisibility,       // head-visibility setter
+        InputDispatch,        // generic input-event dispatcher
+        ActionDispatch,       // global action dispatcher (Lua Player:OnAction source)
+        RayWorldIntersection, // IPhysicalWorld::RayWorldIntersection helper (called, not hooked)
+        InteractionRayBuild,  // interaction ray-query builder
+        InteractorLookRay,    // interactor look-ray builder (used as a caller-range bound, not hooked)
+        InteractionOnScreen,  // on-screen reticle projection gate
+        OverlayHide,          // HideOverlays
+        OverlayShow,          // ShowOverlays
+        MenuOpen,             // UI menu-open entry
+        MenuClose,            // UI menu-close entry
+        Count,
+    };
+
+    /**
+     * @brief Resolves every game-image anchor in one parallel pass and records the results.
+     * @details Builds the declarative DMK::Anchors table over the cascade candidate arrays above (each a
+     *          RipGlobal anchor whose candidates already select Direct vs RIP-relative resolution) and
+     *          resolves it with Anchors::resolve_all_parallel, confined to the WHGame.dll image
+     *          [module_base, module_base + module_size). The explicit range is required: the DMK default
+     *          host_module_range() is the host EXE, not WHGame.dll. Each resolved address is stored for
+     *          anchor_address(); a per-anchor status line plus an assess_quality() summary are logged. A
+     *          best-effort anchor that misses records 0 and its consumer degrades; the mandatory anchors
+     *          (Context, Frustum) are reported so the caller can fail init when anchor_address() is 0.
+     * @note Setup/control-plane only: allocates and spawns a transient worker pool. Call once at init.
+     */
+    void resolve_all_anchors(std::uintptr_t module_base, std::size_t module_size);
+
+    /**
+     * @brief Returns the resolved absolute address for an anchor, or 0 if it did not resolve.
+     * @note Valid only after resolve_all_anchors() has run; returns 0 before then or on a cascade miss.
+     */
+    [[nodiscard]] std::uintptr_t anchor_address(AnchorId id) noexcept;
 } // namespace TPVCamera
 
 #endif // TPVCAMERA_AOB_RESOLVER_HPP

--- a/TPVCamera/src/game_interface.cpp
+++ b/TPVCamera/src/game_interface.cpp
@@ -20,24 +20,24 @@ using DMK::Format::format_address;
 namespace TPVCamera
 {
 
-bool initialize_game_interface(uintptr_t module_base, size_t module_size)
+bool initialize_game_interface()
 {
     DMK::Logger &logger = DMK::Logger::get_instance();
 
     try
     {
-        logger.info("GameInterface: Initializing with dynamic AOB scanning...");
+        logger.info("GameInterface: Initializing from resolved anchors...");
 
-        // The cascade's RipRelative candidates each resolve the same global-context storage slot
-        // (the RIP-relative MOV/load target), so the returned address is the slot directly. The
-        // module-scoped resolver guarantees the slot lies inside the game image or returns 0.
-        const uintptr_t ctx_slot = resolve_address(Aob::k_contextCandidates, "GlobalContextPtr", module_base, module_size);
+        // The Context cascade's RipRelative candidates each resolve the same global-context storage slot
+        // (the RIP-relative MOV/load target), so anchor_address returns the slot directly, or 0 if the
+        // module-scoped resolution missed.
+        const uintptr_t ctx_slot = anchor_address(AnchorId::Context);
         if (ctx_slot == 0)
         {
             throw std::runtime_error("Context pointer cascade did not resolve");
         }
 
-        g_global_context_ptr_address = reinterpret_cast<std::byte *>(ctx_slot);
+        g_global_context_ptr_address.store(reinterpret_cast<std::byte *>(ctx_slot), std::memory_order_relaxed);
 
         logger.info("GameInterface: Global context pointer storage at {}", format_address(ctx_slot));
 
@@ -52,7 +52,7 @@ bool initialize_game_interface(uintptr_t module_base, size_t module_size)
 
 void cleanup_game_interface()
 {
-    g_global_context_ptr_address = nullptr;
+    g_global_context_ptr_address.store(nullptr, std::memory_order_relaxed);
 }
 
 } // namespace TPVCamera

--- a/TPVCamera/src/game_interface.hpp
+++ b/TPVCamera/src/game_interface.hpp
@@ -9,21 +9,17 @@
 #ifndef TPVCAMERA_GAME_INTERFACE_HPP
 #define TPVCAMERA_GAME_INTERFACE_HPP
 
-#include <cstdint>
-#include <cstddef>
-
 namespace TPVCamera
 {
 
 /**
- * @brief Initialize game interface with dynamic AOB scanning.
- * @details Resolves the global-context pointer storage from the module image and stores it for the
+ * @brief Stores the resolved global-context pointer for the game-state camera reads.
+ * @details Reads the Context anchor (resolved by resolve_all_anchors()) and stores the slot for the
  *          game-state camera reads (game_state.cpp); without this call those reads find no state.
- * @param module_base Base address of the target game module.
- * @param module_size Size of the target game module in bytes.
- * @return true if initialization successful, false otherwise.
+ * @return true if the context anchor resolved, false otherwise.
+ * @note Call after resolve_all_anchors().
  */
-[[nodiscard]] bool initialize_game_interface(uintptr_t module_base, size_t module_size);
+[[nodiscard]] bool initialize_game_interface();
 
 /**
  * @brief Clean up game interface resources.

--- a/TPVCamera/src/game_state.cpp
+++ b/TPVCamera/src/game_state.cpp
@@ -68,26 +68,18 @@ namespace
  */
 [[nodiscard]] uint32_t poll_active_camera_state() noexcept
 {
-    if (!g_global_context_ptr_address)
+    const auto context_slot = g_global_context_ptr_address.load(std::memory_order_relaxed);
+    if (!context_slot)
     {
         return 0;
     }
-    const auto context = DMK::Memory::seh_read<uintptr_t>(reinterpret_cast<uintptr_t>(g_global_context_ptr_address));
-    if (!context || !DMK::Memory::plausible_userspace_ptr(*context))
-    {
-        return 0;
-    }
-    const auto manager = DMK::Memory::seh_read<uintptr_t>(*context + Constants::OFFSET_MANAGER_PTR_STORAGE);
-    if (!manager || !DMK::Memory::plausible_userspace_ptr(*manager))
-    {
-        return 0;
-    }
-    const auto active_camera = DMK::Memory::seh_read<uintptr_t>(*manager + Constants::OFFSET_ACTIVE_CAMERA);
-    if (!active_camera || !DMK::Memory::plausible_userspace_ptr(*active_camera))
-    {
-        return 0;
-    }
-    const auto vtable = DMK::Memory::seh_read<uintptr_t>(*active_camera);
+    // One guarded walk: g_global_context -> camera manager (OFFSET_MANAGER_PTR_STORAGE) -> active camera
+    // (OFFSET_ACTIVE_CAMERA) -> vtable. seh_read_chain screens every intermediate link with
+    // plausible_userspace_ptr under a single fault guard; the terminal vtable value it returns is not
+    // range-checked by the chain, so it is screened here to match the previous per-hop walk.
+    const auto vtable = DMK::Memory::seh_read_chain<uintptr_t>(
+        reinterpret_cast<uintptr_t>(context_slot),
+        {0, Constants::OFFSET_MANAGER_PTR_STORAGE, Constants::OFFSET_ACTIVE_CAMERA, 0});
     if (!vtable || !DMK::Memory::plausible_userspace_ptr(*vtable))
     {
         return 0;
@@ -141,27 +133,19 @@ namespace
  */
 [[nodiscard]] uint32_t poll_active_minigame(uintptr_t c_player) noexcept
 {
-    if (!g_global_context_ptr_address)
+    const auto context_slot = g_global_context_ptr_address.load(std::memory_order_relaxed);
+    if (!context_slot)
     {
         return 0;
     }
-    const auto context = DMK::Memory::seh_read<uintptr_t>(reinterpret_cast<uintptr_t>(g_global_context_ptr_address));
-    if (!context || !DMK::Memory::plausible_userspace_ptr(*context))
-    {
-        return 0;
-    }
-    const auto subsystem = DMK::Memory::seh_read<uintptr_t>(*context + Constants::OFFSET_MINIGAME_SUBSYSTEM);
-    if (!subsystem || !DMK::Memory::plausible_userspace_ptr(*subsystem))
-    {
-        return 0;
-    }
-    const auto manager = DMK::Memory::seh_read<uintptr_t>(*subsystem + Constants::OFFSET_MINIGAME_MANAGER);
-    if (!manager || !DMK::Memory::plausible_userspace_ptr(*manager))
-    {
-        return 0;
-    }
-    // Sentinel head of the circular list: an empty map links the head's next back to the head itself.
-    const auto head = DMK::Memory::seh_read<uintptr_t>(*manager + Constants::OFFSET_MINIGAME_MAP_HEAD);
+    // Walk g_global_context -> minigame subsystem -> manager -> circular-list sentinel head under one
+    // fault guard (each intermediate link screened by plausible_userspace_ptr). The head value the chain
+    // returns is screened here (the chain does not range-check the terminal read). An empty map links the
+    // head's next back to the head itself, so the begin read below is deliberately NOT plausibility-screened.
+    const auto head = DMK::Memory::seh_read_chain<uintptr_t>(
+        reinterpret_cast<uintptr_t>(context_slot),
+        {0, Constants::OFFSET_MINIGAME_SUBSYSTEM, Constants::OFFSET_MINIGAME_MANAGER,
+         Constants::OFFSET_MINIGAME_MAP_HEAD});
     if (!head || !DMK::Memory::plausible_userspace_ptr(*head))
     {
         return 0;

--- a/TPVCamera/src/global_state.cpp
+++ b/TPVCamera/src/global_state.cpp
@@ -8,7 +8,7 @@
 // Stable unmangled symbol for the resolved game context pointer (see header).
 extern "C"
 {
-    std::byte *g_global_context_ptr_address = nullptr;
+    std::atomic<std::byte *> g_global_context_ptr_address{nullptr};
 }
 
 namespace TPVCamera
@@ -29,6 +29,89 @@ namespace TPVCamera
     {
         static CameraState state;
         return state;
+    }
+
+    void InteractionAimPose::store(float px, float py, float pz, float dx, float dy, float dz) noexcept
+    {
+        const std::uint32_t seq = m_seq.load(std::memory_order_relaxed);
+        m_seq.store(seq + 1, std::memory_order_relaxed); // odd: write in progress
+        // Release fence: the odd-marker store cannot be reordered after the payload stores below it, so the
+        // "write in progress" sequence is established before any field changes. A reader that catches a
+        // half-written payload then sees an odd (or, after the even publish, a changed) sequence on its
+        // re-read and retries.
+        std::atomic_thread_fence(std::memory_order_release);
+        m_pos_x.store(px, std::memory_order_relaxed);
+        m_pos_y.store(py, std::memory_order_relaxed);
+        m_pos_z.store(pz, std::memory_order_relaxed);
+        m_dir_x.store(dx, std::memory_order_relaxed);
+        m_dir_y.store(dy, std::memory_order_relaxed);
+        m_dir_z.store(dz, std::memory_order_relaxed);
+        m_valid.store(true, std::memory_order_relaxed);
+        // Release fence: orders the payload stores before the even-marker publish; it pairs with the
+        // reader's acquire fence so a reader that sees the even sequence sees the whole payload.
+        std::atomic_thread_fence(std::memory_order_release);
+        m_seq.store(seq + 2, std::memory_order_relaxed); // even: published
+    }
+
+    bool InteractionAimPose::load(float &px, float &py, float &pz, float &dx, float &dy, float &dz) const noexcept
+    {
+        // Bounded seqlock read: a hook callback must not spin unboundedly, so cap the retries and fail
+        // closed if the producer is mid-publish across the cap. The producer is a single thread making
+        // forward progress, so in practice the first attempt succeeds.
+        for (int attempt = 0; attempt < 4; ++attempt)
+        {
+            const std::uint32_t before = m_seq.load(std::memory_order_acquire);
+            if (before & 1u)
+                continue; // write in progress
+            const bool valid = m_valid.load(std::memory_order_relaxed);
+            const float lpx = m_pos_x.load(std::memory_order_relaxed);
+            const float lpy = m_pos_y.load(std::memory_order_relaxed);
+            const float lpz = m_pos_z.load(std::memory_order_relaxed);
+            const float ldx = m_dir_x.load(std::memory_order_relaxed);
+            const float ldy = m_dir_y.load(std::memory_order_relaxed);
+            const float ldz = m_dir_z.load(std::memory_order_relaxed);
+            // Acquire fence pairs with the producer's release fences; the relaxed re-read then detects a
+            // publish that overlapped the payload reads.
+            std::atomic_thread_fence(std::memory_order_acquire);
+            if (m_seq.load(std::memory_order_relaxed) != before)
+                continue; // torn across the read; retry
+            if (!valid)
+                return false;
+            px = lpx;
+            py = lpy;
+            pz = lpz;
+            dx = ldx;
+            dy = ldy;
+            dz = ldz;
+            return true;
+        }
+        return false;
+    }
+
+    void InteractionAimPose::invalidate() noexcept
+    {
+        const std::uint32_t seq = m_seq.load(std::memory_order_relaxed);
+        m_seq.store(seq + 1, std::memory_order_relaxed); // odd
+        std::atomic_thread_fence(std::memory_order_release);
+        m_valid.store(false, std::memory_order_relaxed);
+        std::atomic_thread_fence(std::memory_order_release);
+        m_seq.store(seq + 2, std::memory_order_relaxed); // even
+    }
+
+    bool InteractionAimPose::is_valid() const noexcept
+    {
+        for (int attempt = 0; attempt < 4; ++attempt)
+        {
+            const std::uint32_t before = m_seq.load(std::memory_order_acquire);
+            if (before & 1u)
+                continue;
+            const bool valid = m_valid.load(std::memory_order_relaxed);
+            std::atomic_thread_fence(std::memory_order_acquire);
+            if (m_seq.load(std::memory_order_relaxed) != before)
+                continue;
+            return valid;
+        }
+        return false;
     }
 
     InteractionAimPose &interaction_aim_pose() noexcept

--- a/TPVCamera/src/global_state.hpp
+++ b/TPVCamera/src/global_state.hpp
@@ -15,12 +15,16 @@
 #include <cstddef>
 #include <cstdint>
 
-// Resolved base address of the game's global context. Kept as a stable
-// unmangled symbol (rather than namespaced state) so it can be located from
-// external tooling such as Cheat Engine or x64dbg during reverse-engineering.
+// Resolved base address of the game's global context. Kept as a stable unmangled symbol (rather than
+// namespaced state) so it can be located from external tooling such as Cheat Engine or x64dbg during
+// reverse-engineering. Atomic because the render thread reads it (the camera/minigame chain walks in
+// game_state.cpp) while shutdown nulls it on the bootstrap thread before the hooks are removed; relaxed
+// is sufficient (a standalone pointer, no dependent data published through it, and each chain walk
+// independently validates the value it reads). std::atomic<std::byte *> is lock-free and layout-identical
+// to a raw pointer on x64, so external tooling still reads it as a plain pointer.
 extern "C"
 {
-    extern std::byte *g_global_context_ptr_address;
+    extern std::atomic<std::byte *> g_global_context_ptr_address;
 }
 
 namespace TPVCamera
@@ -180,20 +184,60 @@ namespace TPVCamera
      *          shoulder offset (worst at close range -- you cannot interact with what the crosshair is
      *          on). The frustum-builder detour publishes the final rendered camera position + crosshair
      *          direction here each engaged frame; the interactor eye-copy detour reads it to re-origin the
-     *          cone onto the screen centre. valid is true ONLY while the offset is engaged (in first
-     *          person the camera IS the eye, so the hook leaves the game untouched). Written and read on
-     *          different points of the frame (possibly different threads); relaxed atomics are sufficient
-     *          since a one-frame-stale selection pose is harmless.
+     *          cone onto the screen centre. A published pose is valid ONLY while the offset is engaged (in
+     *          first person the camera IS the eye, so the hook leaves the game untouched).
+     *
+     *          The pose is published as a tear-free seqlock snapshot. The producer and consumer run at
+     *          different points of the frame (and possibly on different threads), so reading the seven
+     *          fields independently could mix a position from frame N with a direction from frame N+1 --
+     *          an incoherent pose, not merely a stale one, which would aim the interaction ray at nothing.
+     *          The seqlock makes every read observe one coherent frame or fail closed (no pose). A
+     *          one-frame-stale but coherent pose is harmless for use-target selection.
      */
-    struct InteractionAimPose
+    class InteractionAimPose
     {
-        std::atomic<float> pos_x{0.0f}; // rendered camera position (new cone origin)
-        std::atomic<float> pos_y{0.0f};
-        std::atomic<float> pos_z{0.0f};
-        std::atomic<float> dir_x{0.0f}; // crosshair direction (new scoring axis)
-        std::atomic<float> dir_y{1.0f};
-        std::atomic<float> dir_z{0.0f};
-        std::atomic<bool> valid{false};
+    public:
+        /**
+         * @brief Publishes a coherent pose snapshot (camera position + crosshair direction) as valid.
+         * @details Seqlock writer: marks the sequence odd, writes the payload behind a release fence,
+         *          then marks it even to publish. Single-producer (the frustum-builder detour is the only
+         *          writer). Callback-safe: no allocation, no lock.
+         */
+        void store(float px, float py, float pz, float dx, float dy, float dz) noexcept;
+
+        /**
+         * @brief Reads a coherent pose snapshot.
+         * @param px,py,pz Filled with the rendered camera position (the new cone origin).
+         * @param dx,dy,dz Filled with the crosshair direction (the new scoring axis).
+         * @return true and fills the out params when a valid tear-free pose was read; false when no pose
+         *         is published or the read could not be confirmed tear-free (the out params are untouched).
+         * @note Callback-safe: a bounded retry caps the seqlock spin and fails closed.
+         */
+        [[nodiscard]] bool load(float &px, float &py, float &pz, float &dx, float &dy,
+                                float &dz) const noexcept;
+
+        /// Marks the published pose invalid (first person / offset suppressed).
+        void invalidate() noexcept;
+
+        /// Returns whether a valid pose is currently published (tear-free seqlock read of the flag).
+        [[nodiscard]] bool is_valid() const noexcept;
+
+    private:
+        // Seqlock sequence: even = stable, odd = write in progress. The producer brackets its payload
+        // writes between the odd and even transitions; a reader retries while it observes an odd or
+        // changed sequence, so a partially written pose is never returned.
+        std::atomic<std::uint32_t> m_seq{0};
+        // Pose payload. The seqlock sequence provides coherence (no mixed frame) and the release/acquire
+        // fences provide the publish ordering; the fields are relaxed atomics (not plain) so a producer
+        // store racing a consumer load is well-defined rather than a data race, which keeps the seqlock
+        // correct on any memory model, not just x86 TSO.
+        std::atomic<float> m_pos_x{0.0f};
+        std::atomic<float> m_pos_y{0.0f};
+        std::atomic<float> m_pos_z{0.0f};
+        std::atomic<float> m_dir_x{0.0f};
+        std::atomic<float> m_dir_y{1.0f};
+        std::atomic<float> m_dir_z{0.0f};
+        std::atomic<bool> m_valid{false};
     };
 
     /** @brief Returns the process-wide resolved game module info. */

--- a/TPVCamera/src/hooks/camera_hook.cpp
+++ b/TPVCamera/src/hooks/camera_hook.cpp
@@ -38,6 +38,8 @@
 
 #include <DetourModKit.hpp>
 
+#include <windows.h>
+
 #include <algorithm>
 #include <atomic>
 #include <chrono>
@@ -348,7 +350,11 @@ static void apply_orbit_aim_control_impl(float pitch_ease, bool set_yaw, float y
     }
     // Ease the SCALAR pitch toward 0 (level). Both synchronized copies are written so any internal
     // current/target smoothing also settles at level. A sane pitch is within about +/- 1.6 rad; a
-    // wild or non-finite value means the layout drifted, so that write is skipped.
+    // wild or non-finite value means the layout drifted, so that write is skipped. The stores go
+    // through a volatile pointer: the engine consumes these scalars on its own thread, so volatile
+    // makes the consume-once write explicit and stops the compiler eliding or reordering it (the same
+    // foreign-write intent the body-turn active byte uses; this is a hardware-I/O-style boundary, not
+    // inter-thread synchronization of our own state).
     if (pitch_ease > 0.0f)
     {
         const uintptr_t pitch_addr = *controller + Constants::LOOK_CONTROLLER_PITCH_OFFSET;
@@ -356,18 +362,20 @@ static void apply_orbit_aim_control_impl(float pitch_ease, bool set_yaw, float y
         if (pitch_value && *pitch_value > -3.2f && *pitch_value < 3.2f)
         {
             const float levelled = *pitch_value * (1.0f - pitch_ease);
-            *reinterpret_cast<float *>(pitch_addr) = levelled;
-            *reinterpret_cast<float *>(*controller + Constants::LOOK_CONTROLLER_PITCH2_OFFSET) = levelled;
+            *reinterpret_cast<volatile float *>(pitch_addr) = levelled;
+            *reinterpret_cast<volatile float *>(*controller + Constants::LOOK_CONTROLLER_PITCH2_OFFSET) = levelled;
         }
     }
 
     // Set the look YAW (heading) to face the camera direction. The character moves along this heading,
     // so this is what turns the body and makes movement camera-relative on the idle -> moving edge.
-    // Both synchronized copies are written.
-    if (set_yaw)
+    // Both synchronized copies are written (volatile, as for the pitch). yaw_value is finite-checked
+    // first: a non-finite heading (a layout drift feeding NaN through the derivation) must never be
+    // written into the engine's look state.
+    if (set_yaw && std::isfinite(yaw_value))
     {
-        *reinterpret_cast<float *>(*controller + Constants::LOOK_CONTROLLER_YAW_OFFSET) = yaw_value;
-        *reinterpret_cast<float *>(*controller + Constants::LOOK_CONTROLLER_YAW2_OFFSET) = yaw_value;
+        *reinterpret_cast<volatile float *>(*controller + Constants::LOOK_CONTROLLER_YAW_OFFSET) = yaw_value;
+        *reinterpret_cast<volatile float *>(*controller + Constants::LOOK_CONTROLLER_YAW2_OFFSET) = yaw_value;
     }
 }
 
@@ -507,10 +515,19 @@ static void offset_game_view_camera(uintptr_t camera, uintptr_t cview, uintptr_t
     // than the matrix columns keeps the basis idempotent across the frustum builder's same-frame
     // rebuilds (we overwrite the matrix, never the pose, so the pose stays the clean eye input).
     // The matrix to offset is the camera's 3x4 at offset 0 (cview + SVIEWPARAMS_VIEWMATRIX_OFFSET).
-    const Vector3 eye_position = *reinterpret_cast<const Vector3 *>(
-        cview + Constants::SVIEWPARAMS_POSITION_OFFSET);
-    const Quaternion eye_rotation = *reinterpret_cast<const Quaternion *>(
-        cview + Constants::SVIEWPARAMS_ROTATION_OFFSET);
+    // The eye pose is read through seh_read (memcpy semantics into a trivially-copyable Vector3 /
+    // Quaternion): it screens the source against the low-address floor and a wrap guard, swallows an
+    // access fault via its own SEH frame, and avoids the type-pun UB of a placement reinterpret_cast
+    // read, so a stale/torn cview fails closed here rather than depending solely on the outer detour
+    // SEH frame.
+    const auto eye_position_read = DMK::Memory::seh_read<Vector3>(cview + Constants::SVIEWPARAMS_POSITION_OFFSET);
+    const auto eye_rotation_read = DMK::Memory::seh_read<Quaternion>(cview + Constants::SVIEWPARAMS_ROTATION_OFFSET);
+    if (!eye_position_read || !eye_rotation_read)
+    {
+        return; // CView pose read faulted; leave the view untouched this frame
+    }
+    const Vector3 eye_position = *eye_position_read;
+    const Quaternion eye_rotation = *eye_rotation_read;
     const Vector3 right = eye_rotation.rotate(Vector3{1.0f, 0.0f, 0.0f});
     const Vector3 forward = eye_rotation.rotate(Vector3{0.0f, 1.0f, 0.0f});
     const Vector3 up = eye_rotation.rotate(Vector3{0.0f, 0.0f, 1.0f});
@@ -1359,16 +1376,8 @@ static void offset_game_view_camera(uintptr_t camera, uintptr_t cview, uintptr_t
     // (worst at close range -- you cannot loot/use what the crosshair appears to be on). The hook
     // re-origins the cone onto this pose when InteractFromCamera is set. valid is true only here (while
     // the offset is engaged); the suppression path below clears it, so first person leaves the game alone.
-    {
-        InteractionAimPose &aim = interaction_aim_pose();
-        aim.pos_x.store(final_position.x, std::memory_order_relaxed);
-        aim.pos_y.store(final_position.y, std::memory_order_relaxed);
-        aim.pos_z.store(final_position.z, std::memory_order_relaxed);
-        aim.dir_x.store(screen_forward.x, std::memory_order_relaxed);
-        aim.dir_y.store(screen_forward.y, std::memory_order_relaxed);
-        aim.dir_z.store(screen_forward.z, std::memory_order_relaxed);
-        aim.valid.store(true, std::memory_order_relaxed);
-    }
+    interaction_aim_pose().store(final_position.x, final_position.y, final_position.z, screen_forward.x,
+                                 screen_forward.y, screen_forward.z);
 }
 
 /**
@@ -1713,7 +1722,7 @@ static void detour_frustum_build_impl(uintptr_t camera)
         cam.collision_valid = false;
         cam.collision_hold_timer = 0.0f;
         // First person (or suppressed): the camera is the eye, so the interaction hook must NOT redirect.
-        interaction_aim_pose().valid.store(false, std::memory_order_relaxed);
+        interaction_aim_pose().invalidate();
         cam.orbit_level_blend = 0.0f;
         cam.orbit_render_valid = false; // next engaged frame snaps the orbit low-pass instead of easing across the gap
         cam.orbit_steer_valid = false;  // and the continuous-align steer low-pass
@@ -1916,13 +1925,14 @@ static void __fastcall detour_input_dispatch(uintptr_t controller, uintptr_t inp
  *          result is screened as a plausible user-space pointer before it is accepted.
  * @return The g_env base address (cascade result, or the static fallback).
  */
-static uintptr_t resolve_genv(uintptr_t module_base, size_t module_size)
+static uintptr_t resolve_genv(uintptr_t module_base)
 {
     DMK::Logger &logger = DMK::Logger::get_instance();
 
-    // The cascade's RipRelative candidates each resolve the g_env base from a different
-    // lea/mov [rip+g_env] reference site; the result is screened as a plausible pointer.
-    const uintptr_t resolved = resolve_address(Aob::k_genvCandidates, "Genv", module_base, module_size);
+    // The Genv cascade's RipRelative candidates each resolve the g_env base from a different
+    // lea/mov [rip+g_env] reference site (resolved up front by resolve_all_anchors()); the result is
+    // screened as a plausible pointer.
+    const uintptr_t resolved = anchor_address(AnchorId::Genv);
     if (resolved != 0 && DMK::Memory::plausible_userspace_ptr(resolved))
     {
         logger.info("Camera: g_env resolved via AOB at {}", DMK::Format::format_address(resolved));
@@ -1948,7 +1958,7 @@ bool initialize_camera(uintptr_t module_base, size_t module_size)
 
     // Resolve g_env once (patch-resilient AOB, static RVA fallback). The CView vtable is
     // identified lazily by RTTI on the first game-view camera, so nothing is resolved here.
-    s_genv_runtime = resolve_genv(module_base, module_size);
+    s_genv_runtime = resolve_genv(module_base);
 
     // Resolve the engine ray helper for collision + aim convergence. Best-effort: on a miss
     // those features no-op (the camera still renders), so the result is intentionally discarded.
@@ -1958,10 +1968,14 @@ bool initialize_camera(uintptr_t module_base, size_t module_size)
     {
         DMK::HookManager &hook_manager = DMK::HookManager::get_instance();
 
+        // Fail closed if a resolved entry leads with a call/breakpoint byte (a cascade mis-resolution or
+        // a foreign int3 stub); a sibling mod's E9 jump-hook does not trip this, so layering still works.
+        const DMK::HookConfig hook_config{.prologue_policy = DMK::InlineProloguePolicy::Fail};
+
         // Hook the camera frustum builder -- the matrix-offset point; without it the feature
         // does nothing. The module-scoped cascade resolves to the function entry inside the game
         // image or returns 0, so no separate bounds check is needed here.
-        const uintptr_t frustum_addr = resolve_address(Aob::k_frustumCandidates, "CameraFrustumBuild", module_base, module_size);
+        const uintptr_t frustum_addr = anchor_address(AnchorId::Frustum);
         if (frustum_addr == 0)
         {
             throw std::runtime_error("Failed to resolve frustum builder cascade");
@@ -1970,7 +1984,8 @@ bool initialize_camera(uintptr_t module_base, size_t module_size)
             "CameraFrustumBuild",
             frustum_addr,
             reinterpret_cast<void *>(detour_frustum_build),
-            reinterpret_cast<void **>(&s_frustum_build_original));
+            reinterpret_cast<void **>(&s_frustum_build_original),
+            hook_config);
 
         if (!frustum_result.has_value())
         {
@@ -1980,7 +1995,7 @@ bool initialize_camera(uintptr_t module_base, size_t module_size)
 
         // The head-visibility hook is best-effort: if it fails the camera still works,
         // the player just appears headless from behind, so a miss is a warning.
-        const uintptr_t head_addr = resolve_address(Aob::k_headVisibilityCandidates, "SetHeadVisibility", module_base, module_size);
+        const uintptr_t head_addr = anchor_address(AnchorId::HeadVisibility);
         if (head_addr == 0)
         {
             logger.warning("Camera: Head visibility cascade unresolved; player may appear headless from behind");
@@ -1991,7 +2006,8 @@ bool initialize_camera(uintptr_t module_base, size_t module_size)
                 "SetHeadVisibility",
                 head_addr,
                 reinterpret_cast<void *>(detour_set_head_visibility),
-                reinterpret_cast<void **>(&s_set_head_visibility_original));
+                reinterpret_cast<void **>(&s_set_head_visibility_original),
+                hook_config);
 
             if (!head_result.has_value())
             {
@@ -2003,7 +2019,7 @@ bool initialize_camera(uintptr_t module_base, size_t module_size)
         // The input-dispatcher hook powers free-look orbit. Best-effort: a miss only
         // disables orbit, the offset camera still works. The detour is inert until the
         // orbit key is held, so it is harmless when free-look is unused.
-        const uintptr_t input_addr = resolve_address(Aob::k_inputDispatchCandidates, "CameraInputDispatch", module_base, module_size);
+        const uintptr_t input_addr = anchor_address(AnchorId::InputDispatch);
         if (input_addr == 0)
         {
             logger.warning("Camera: Input dispatcher cascade unresolved; free-look orbit unavailable");
@@ -2014,7 +2030,8 @@ bool initialize_camera(uintptr_t module_base, size_t module_size)
                 "CameraInputDispatch",
                 input_addr,
                 reinterpret_cast<void *>(detour_input_dispatch),
-                reinterpret_cast<void **>(&s_input_dispatch_original));
+                reinterpret_cast<void **>(&s_input_dispatch_original),
+                hook_config);
 
             if (!input_result.has_value())
             {

--- a/TPVCamera/src/hooks/interaction_hook.cpp
+++ b/TPVCamera/src/hooks/interaction_hook.cpp
@@ -99,13 +99,12 @@ std::atomic<unsigned long long> s_onscreen_forced{0}; // checks force-passed for
  */
 bool redirect_interaction_ray(uintptr_t origin, uintptr_t dir) noexcept
 {
-    InteractionAimPose &aim = interaction_aim_pose();
-    const float px = aim.pos_x.load(std::memory_order_relaxed);
-    const float py = aim.pos_y.load(std::memory_order_relaxed);
-    const float pz = aim.pos_z.load(std::memory_order_relaxed);
-    const float dx = aim.dir_x.load(std::memory_order_relaxed);
-    const float dy = aim.dir_y.load(std::memory_order_relaxed);
-    const float dz = aim.dir_z.load(std::memory_order_relaxed);
+    float px, py, pz, dx, dy, dz;
+    if (!interaction_aim_pose().load(px, py, pz, dx, dy, dz))
+    {
+        // No coherent valid pose (first person, or raced with an invalidate); leave the ray unchanged.
+        return false;
+    }
 
     float eye[3] = {0.0f, 0.0f, 0.0f};
     float dold[3] = {0.0f, 0.0f, 0.0f};
@@ -212,7 +211,7 @@ uintptr_t __fastcall ray_query_build_detour(uintptr_t out, uintptr_t origin, uin
         {
             s_last_reason = "InteractFromCamera=off";
         }
-        else if (!interaction_aim_pose().valid.load(std::memory_order_relaxed))
+        else if (!interaction_aim_pose().is_valid())
         {
             s_last_reason = "first-person (offset not engaged)";
         }
@@ -250,8 +249,9 @@ char __fastcall on_screen_check_detour(uintptr_t a1, uintptr_t a2, float *a3, ui
 {
     s_onscreen_calls.fetch_add(1, std::memory_order_relaxed);
 
+    float ex, ey, ez, dx, dy, dz;
     if (a2 == 0 || a3 == nullptr || !settings().interact_from_camera.load(std::memory_order_relaxed) ||
-        !interaction_aim_pose().valid.load(std::memory_order_relaxed))
+        !interaction_aim_pose().load(ex, ey, ez, dx, dy, dz))
     {
         return s_onscreen_original(a1, a2, a3, a4);
     }
@@ -260,13 +260,6 @@ char __fastcall on_screen_check_detour(uintptr_t a1, uintptr_t a2, float *a3, ui
     __try
     {
         const float *p = reinterpret_cast<const float *>(a2); // candidate world interaction point
-        InteractionAimPose &aim = interaction_aim_pose();
-        const float ex = aim.pos_x.load(std::memory_order_relaxed);
-        const float ey = aim.pos_y.load(std::memory_order_relaxed);
-        const float ez = aim.pos_z.load(std::memory_order_relaxed);
-        const float dx = aim.dir_x.load(std::memory_order_relaxed);
-        const float dy = aim.dir_y.load(std::memory_order_relaxed);
-        const float dz = aim.dir_z.load(std::memory_order_relaxed);
         const float vx = p[0] - ex, vy = p[1] - ey, vz = p[2] - ez;
         const float t = vx * dx + vy * dy + vz * dz; // projection onto the crosshair ray (unit dir)
         if (t > 0.1f)                                 // candidate must be in front of the camera
@@ -295,16 +288,20 @@ char __fastcall on_screen_check_detour(uintptr_t a1, uintptr_t a2, float *a3, ui
 
 } // namespace
 
-bool initialize_interaction_hook(uintptr_t module_base, size_t module_size)
+bool initialize_interaction_hook()
 {
     DMK::Logger &logger = DMK::Logger::get_instance();
 
+    // Fail closed if a resolved entry leads with a call/breakpoint byte; a sibling mod's E9 jump-hook
+    // does not trip this, so the cascade's entry-anchored layering still works.
+    const DMK::HookConfig hook_config{.prologue_policy = DMK::InlineProloguePolicy::Fail};
+
     try
     {
-        // Resolve the interactor look-ray builder entry -> the caller-range filter bound. The
-        // module-scoped cascade keeps the resolved entry inside the game image or returns 0, so a
-        // cross-module collision can no longer yield a bogus return-address range.
-        const uintptr_t lookray = resolve_address(Aob::k_interactorLookRayCandidates, "InteractorLookRay", module_base, module_size);
+        // The interactor look-ray builder entry -> the caller-range filter bound. The module-scoped
+        // cascade kept the resolved entry inside the game image or returns 0, so a cross-module collision
+        // can no longer yield a bogus return-address range.
+        const uintptr_t lookray = anchor_address(AnchorId::InteractorLookRay);
         if (lookray == 0)
         {
             throw std::runtime_error("Interactor look-ray builder cascade did not resolve");
@@ -313,7 +310,7 @@ bool initialize_interaction_hook(uintptr_t module_base, size_t module_size)
         s_lookray_hi = s_lookray_lo + Constants::INTERACTOR_LOOKRAY_SPAN;
 
         // Hook the ray-query builder.
-        const uintptr_t hook_addr = resolve_address(Aob::k_interactionRayBuildCandidates, "InteractionRayBuild", module_base, module_size);
+        const uintptr_t hook_addr = anchor_address(AnchorId::InteractionRayBuild);
         if (hook_addr == 0)
         {
             throw std::runtime_error("Interaction ray-build cascade did not resolve");
@@ -323,7 +320,8 @@ bool initialize_interaction_hook(uintptr_t module_base, size_t module_size)
             "InteractionRayBuild",
             hook_addr,
             reinterpret_cast<void *>(ray_query_build_detour),
-            reinterpret_cast<void **>(&s_original));
+            reinterpret_cast<void **>(&s_original),
+            hook_config);
         if (!result.has_value())
         {
             throw std::runtime_error("Failed to create interaction ray hook: " +
@@ -332,14 +330,15 @@ bool initialize_interaction_hook(uintptr_t module_base, size_t module_size)
 
         // Hook the on-screen reticle projection gate -- the gate that drops shrines/beds/doors when the
         // body is not turned. Non-fatal: failure leaves shrine interaction body-driven.
-        const uintptr_t onscreen = resolve_address(Aob::k_interactionOnScreenCandidates, "InteractionOnScreenCheck", module_base, module_size);
+        const uintptr_t onscreen = anchor_address(AnchorId::InteractionOnScreen);
         if (onscreen != 0)
         {
             auto onscreen_result = DMK::HookManager::get_instance().create_inline_hook(
                 "InteractionOnScreenCheck",
                 onscreen,
                 reinterpret_cast<void *>(on_screen_check_detour),
-                reinterpret_cast<void **>(&s_onscreen_original));
+                reinterpret_cast<void **>(&s_onscreen_original),
+                hook_config);
             if (!onscreen_result.has_value())
             {
                 logger.warning("InteractionHook[init]: on-screen reticle hook failed ({}); shrine "

--- a/TPVCamera/src/hooks/interaction_hook.hpp
+++ b/TPVCamera/src/hooks/interaction_hook.hpp
@@ -13,23 +13,19 @@
 #ifndef TPVCAMERA_HOOKS_INTERACTION_HOOK_HPP
 #define TPVCAMERA_HOOKS_INTERACTION_HOOK_HPP
 
-#include <cstddef>
-#include <cstdint>
-
 namespace TPVCamera
 {
 
 /**
  * @brief Installs the interaction look-ray redirect (sub_180530584) and the on-screen reticle gate
- *        (sub_18093C170).
+ *        (sub_18093C170) from the pre-resolved anchors.
  * @details Best-effort: on a pattern miss the feature simply no-ops (interaction stays vanilla) and the
  *          rest of the mod is unaffected. The detours are also a no-op at runtime unless InteractFromCamera
  *          is enabled AND the third-person offset is engaged, so first person is never touched.
- * @param module_base Resolved WHGame.DLL base.
- * @param module_size WHGame.DLL image size.
  * @return true if the look-ray builder hook was installed.
+ * @note Call after resolve_all_anchors(); the hook targets are read via anchor_address().
  */
-[[nodiscard]] bool initialize_interaction_hook(uintptr_t module_base, size_t module_size);
+[[nodiscard]] bool initialize_interaction_hook();
 
 } // namespace TPVCamera
 

--- a/TPVCamera/src/hooks/player_onaction_hook.cpp
+++ b/TPVCamera/src/hooks/player_onaction_hook.cpp
@@ -8,12 +8,15 @@
 
 #include <DetourModKit.hpp>
 
+#include <windows.h>
+
+#include <array>
 #include <atomic>
 #include <cmath>
-#include <cstring>
 #include <exception>
 #include <mutex>
 #include <string>
+#include <string_view>
 #include <vector>
 
 namespace TPVCamera
@@ -38,12 +41,12 @@ static std::atomic<bool> s_available{false};
 // -1..1, magnitude taken). The input is nonzero the instant a key is pressed and stays nonzero while a key is
 // held against a wall, which body-position speed cannot do. The probe below logs each distinct action name
 // once (trace level) so this vocabulary can be confirmed at runtime.
-static const char *k_move_actions[] = {
+static constexpr std::array<std::string_view, 8> k_move_actions = {
     "moveforward", "moveback", "moveleft", "moveright", // keyboard digital (one per direction)
     "xi_movey", "xi_movex",                             // gamepad left-stick (signed analog)
     "movement_y", "movement_x",                         // named analog aliases (some device/rebind paths)
 };
-static constexpr size_t k_move_count = sizeof(k_move_actions) / sizeof(k_move_actions[0]);
+static constexpr size_t k_move_count = k_move_actions.size();
 
 // One latched |value| per movement action, written on the input thread and read on the render thread.
 // Value-initialized to 0; relaxed atomics suffice (a one-frame-stale signal is harmless).
@@ -137,10 +140,13 @@ static void capture_movement_input(const char **action_name, float value)
     // Latch this action's magnitude (|value|) into its own slot; player_onaction_move_magnitude takes the
     // largest across slots. Each action owns a slot, so an independent release (value 0) does not clobber
     // another still-held source (keyboard + stick). Digital keys report ~1 held / 0 released; an analog axis
-    // reports a signed deflection, so its magnitude is taken regardless of direction.
+    // reports a signed deflection, so its magnitude is taken regardless of direction. The name is screened
+    // above; building the view here (one strlen) runs under the detour's SEH frame, so even a malformed
+    // engine string fails closed rather than faulting.
+    const std::string_view name_view(name);
     for (size_t i = 0; i < k_move_count; ++i)
     {
-        if (std::strcmp(name, k_move_actions[i]) == 0)
+        if (k_move_actions[i] == name_view)
         {
             s_move_values[i].store(std::fabs(value), std::memory_order_relaxed);
             break;
@@ -168,12 +174,12 @@ static uintptr_t __fastcall detour_action_dispatch(uintptr_t self, const char **
                : 0;
 }
 
-bool initialize_player_onaction_hook(uintptr_t module_base, size_t module_size)
+bool initialize_player_onaction_hook()
 {
     DMK::Logger &logger = DMK::Logger::get_instance();
     try
     {
-        const uintptr_t dispatch_addr = resolve_address(Aob::k_actionDispatchCandidates, "PlayerOnActionDispatch", module_base, module_size);
+        const uintptr_t dispatch_addr = anchor_address(AnchorId::ActionDispatch);
         if (dispatch_addr == 0)
         {
             logger.warning(
@@ -182,10 +188,14 @@ bool initialize_player_onaction_hook(uintptr_t module_base, size_t module_size)
         }
 
         DMK::HookManager &hook_manager = DMK::HookManager::get_instance();
+        // Fail closed if the resolved entry leads with a call/breakpoint byte (a sibling mod's E9 jump
+        // hook does not trip this, so layering still works).
+        const DMK::HookConfig hook_config{.prologue_policy = DMK::InlineProloguePolicy::Fail};
         auto result = hook_manager.create_inline_hook(
             "PlayerOnActionDispatch", dispatch_addr,
             reinterpret_cast<void *>(detour_action_dispatch),
-            reinterpret_cast<void **>(&s_action_dispatch_original));
+            reinterpret_cast<void **>(&s_action_dispatch_original),
+            hook_config);
 
         if (!result.has_value())
         {

--- a/TPVCamera/src/hooks/player_onaction_hook.hpp
+++ b/TPVCamera/src/hooks/player_onaction_hook.hpp
@@ -16,17 +16,15 @@
 #ifndef TPVCAMERA_PLAYER_ONACTION_HOOK_HPP
 #define TPVCAMERA_PLAYER_ONACTION_HOOK_HPP
 
-#include <cstddef>
-#include <cstdint>
-
 namespace TPVCamera
 {
 
 /**
- * @brief Installs the player OnAction / action-dispatcher hook.
+ * @brief Installs the player OnAction / action-dispatcher hook from the pre-resolved anchor.
  * @return true if the dispatcher was located and hooked.
+ * @note Call after resolve_all_anchors(); the hook target is read via anchor_address().
  */
-[[nodiscard]] bool initialize_player_onaction_hook(uintptr_t module_base, size_t module_size);
+[[nodiscard]] bool initialize_player_onaction_hook();
 
 /** @brief Whether the OnAction hook resolved (callers use the input signal only when true). */
 [[nodiscard]] bool player_onaction_available();

--- a/TPVCamera/src/hooks/ui_menu_hooks.cpp
+++ b/TPVCamera/src/hooks/ui_menu_hooks.cpp
@@ -30,90 +30,56 @@ static std::atomic<bool> s_is_menu_open(false);
 
 /**
  * @brief Detour for the menu-open function (inline hook at its entry point).
- * @details Records the menu-open state, then calls the original. Only the mod-side
- *          work is guarded by try/catch; the original is invoked exactly once
- *          outside the guard so an exception in the mod logic can never call the
- *          engine function twice.
+ * @details Records the menu-open state, then calls the original exactly once. No SEH frame and no C++
+ *          try: the detour only logs through the no-throw logger and stores a mod-owned atomic, so it
+ *          performs no foreign-memory dereference and cannot throw. The original is invoked outside any
+ *          guard so the engine function runs exactly once.
  * @param this_ptr Pointer to the UI menu object
  * @param param_byte Parameter passed to the original function
  */
 static void __fastcall menu_open_detour(void *this_ptr, char param_byte)
 {
-    DMK::Logger &logger = DMK::Logger::get_instance();
-
-    try
-    {
-        logger.debug("UIMenuHook: Game menu is opening");
-
-        s_is_menu_open.store(true);
-    }
-    catch (const std::exception &e)
-    {
-        logger.error("UIMenuHook: Exception in menu open detour: {}", e.what());
-    }
-    catch (...)
-    {
-        logger.error("UIMenuHook: Unknown exception in menu open detour");
-    }
+    (void)DMK::Logger::get_instance().log_noexcept(DMK::LogLevel::Debug, "UIMenuHook: Game menu is opening");
+    s_is_menu_open.store(true, std::memory_order_relaxed);
 
     if (s_menu_open_original)
     {
         s_menu_open_original(this_ptr, param_byte);
     }
-    else
-    {
-        logger.error("UIMenuHook: Menu open original function pointer is NULL");
-    }
 }
 
 /**
  * @brief Detour for the menu-close function (inline hook at its entry point).
- * @details Clears the menu-open state, then calls the original. Only the mod-side
- *          work is guarded by try/catch; the original is invoked exactly once
- *          outside the guard so an exception in the mod logic can never call the
- *          engine function twice.
+ * @details Clears the menu-open state, then calls the original exactly once. As for the open detour, no
+ *          SEH frame and no C++ try are needed: it only logs (no-throw) and stores a mod-owned atomic.
  * @param this_ptr Pointer to the UI menu object
  */
 static void __fastcall menu_close_detour(void *this_ptr)
 {
-    DMK::Logger &logger = DMK::Logger::get_instance();
-
-    try
-    {
-        logger.debug("UIMenuHook: Game menu is closing");
-
-        s_is_menu_open.store(false);
-    }
-    catch (const std::exception &e)
-    {
-        logger.error("UIMenuHook: Exception in menu close detour: {}", e.what());
-    }
-    catch (...)
-    {
-        logger.error("UIMenuHook: Unknown exception in menu close detour");
-    }
+    (void)DMK::Logger::get_instance().log_noexcept(DMK::LogLevel::Debug, "UIMenuHook: Game menu is closing");
+    s_is_menu_open.store(false, std::memory_order_relaxed);
 
     if (s_menu_close_original)
     {
         s_menu_close_original(this_ptr);
     }
-    else
-    {
-        logger.error("UIMenuHook: Menu close original function pointer is NULL");
-    }
 }
 
-bool initialize_ui_menu_hooks(uintptr_t module_base, size_t module_size)
+bool initialize_ui_menu_hooks()
 {
     DMK::Logger &logger = DMK::Logger::get_instance();
 
+    // Fail closed if the resolved entry leads with a call/breakpoint byte; a sibling mod's E9 jump-hook
+    // does not trip this gate, so the cascade's entry-anchored layering still works.
+    const DMK::HookConfig hook_config{.prologue_policy = DMK::InlineProloguePolicy::Fail};
+
     try
     {
-        // Each cascade resolves the function entry directly (P1 anchors on the entry; the
-        // mid-body P2/P3 fallbacks walk back to it via their negative disp_offset). The
-        // module-scoped resolver keeps each entry inside the game image or returns 0.
-        const uintptr_t menu_open_addr = resolve_address(Aob::k_menuOpenCandidates, "MenuOpen", module_base, module_size);
-        const uintptr_t menu_close_addr = resolve_address(Aob::k_menuCloseCandidates, "MenuClose", module_base, module_size);
+        // Each cascade resolves the function entry directly (P1 anchors on the entry; the mid-body P2/P3
+        // fallbacks walk back to it via their negative disp_offset), resolved up front by
+        // resolve_all_anchors() and read here via anchor_address().
+        const uintptr_t menu_open_addr = anchor_address(AnchorId::MenuOpen);
+        const uintptr_t menu_close_addr = anchor_address(AnchorId::MenuClose);
         if (menu_open_addr == 0 || menu_close_addr == 0)
         {
             throw std::runtime_error("Menu function entry cascade did not resolve");
@@ -125,7 +91,8 @@ bool initialize_ui_menu_hooks(uintptr_t module_base, size_t module_size)
             "MenuOpen",
             menu_open_addr,
             reinterpret_cast<void *>(menu_open_detour),
-            reinterpret_cast<void **>(&s_menu_open_original));
+            reinterpret_cast<void **>(&s_menu_open_original),
+            hook_config);
 
         if (!open_result.has_value())
         {
@@ -136,7 +103,8 @@ bool initialize_ui_menu_hooks(uintptr_t module_base, size_t module_size)
             "MenuClose",
             menu_close_addr,
             reinterpret_cast<void *>(menu_close_detour),
-            reinterpret_cast<void **>(&s_menu_close_original));
+            reinterpret_cast<void **>(&s_menu_close_original),
+            hook_config);
 
         if (!close_result.has_value())
         {

--- a/TPVCamera/src/hooks/ui_menu_hooks.hpp
+++ b/TPVCamera/src/hooks/ui_menu_hooks.hpp
@@ -8,19 +8,15 @@
 #ifndef TPVCAMERA_UI_MENU_HOOKS_HPP
 #define TPVCAMERA_UI_MENU_HOOKS_HPP
 
-#include <cstdint>
-#include <cstddef>
-
 namespace TPVCamera
 {
 
 /**
- * @brief Initialize UI menu hooks.
- * @param module_base Base address of the target game module.
- * @param module_size Size of the target game module in bytes.
- * @return true if initialization successful, false otherwise.
+ * @brief Installs the UI menu open/close hooks from the pre-resolved anchors.
+ * @return true if both hooks installed, false otherwise.
+ * @note Call after resolve_all_anchors(); the hook targets are read via anchor_address().
  */
-[[nodiscard]] bool initialize_ui_menu_hooks(uintptr_t module_base, size_t module_size);
+[[nodiscard]] bool initialize_ui_menu_hooks();
 
 /**
  * @brief Check if the in-game menu is currently open.

--- a/TPVCamera/src/hooks/ui_overlay_hooks.cpp
+++ b/TPVCamera/src/hooks/ui_overlay_hooks.cpp
@@ -29,8 +29,10 @@ static ShowOverlaysFunc s_show_overlays_original = nullptr;
 
 /**
  * @brief HideOverlays detour: a UI element is about to show, so mark the overlay active.
- * @details Calls the original exactly once before the mod-side flag store; guarding
- *          the original inside the try would let an exception call it a second time.
+ * @details Calls the original exactly once before the mod-side flag store. No SEH frame is needed
+ *          (unlike the deref-heavy camera/interaction detours): this detour only calls the trampoline
+ *          (the engine's own function, whose faults are the engine's) and stores a mod-owned atomic, so
+ *          it performs no foreign-memory dereference of its own.
  */
 static void __fastcall hide_overlays_detour(void *this_ptr, uint8_t param_byte, char param_char)
 {
@@ -43,7 +45,9 @@ static void __fastcall hide_overlays_detour(void *this_ptr, uint8_t param_byte, 
 
 /**
  * @brief ShowOverlays detour: the UI element is closing, so clear the overlay flag.
- * @details Calls the original exactly once before the mod-side flag store.
+ * @details Calls the original exactly once before the mod-side flag store. No SEH frame is needed: like
+ *          the hide detour it only calls the trampoline and stores a mod-owned atomic, performing no
+ *          foreign-memory dereference of its own.
  */
 static void __fastcall show_overlays_detour(void *this_ptr, uint8_t param_byte, char param_char)
 {
@@ -54,15 +58,19 @@ static void __fastcall show_overlays_detour(void *this_ptr, uint8_t param_byte, 
     overlay_state().active.store(false, std::memory_order_relaxed);
 }
 
-bool initialize_ui_overlay_hooks(uintptr_t module_base, size_t module_size)
+bool initialize_ui_overlay_hooks()
 {
     DMK::Logger &logger = DMK::Logger::get_instance();
+
+    // Fail closed if the resolved entry leads with a call/breakpoint byte (a cascade mis-resolution or a
+    // foreign int3 stub); a sibling mod's E9 jump-hook does not trip this gate, so layering still works.
+    const DMK::HookConfig hook_config{.prologue_policy = DMK::InlineProloguePolicy::Fail};
 
     try
     {
         DMK::HookManager &hook_manager = DMK::HookManager::get_instance();
 
-        const uintptr_t hide_addr = resolve_address(Aob::k_overlayHideCandidates, "HideOverlays", module_base, module_size);
+        const uintptr_t hide_addr = anchor_address(AnchorId::OverlayHide);
         if (hide_addr == 0)
         {
             throw std::runtime_error("HideOverlays cascade did not resolve");
@@ -71,7 +79,8 @@ bool initialize_ui_overlay_hooks(uintptr_t module_base, size_t module_size)
             "HideOverlays",
             hide_addr,
             reinterpret_cast<void *>(hide_overlays_detour),
-            reinterpret_cast<void **>(&s_hide_overlays_original));
+            reinterpret_cast<void **>(&s_hide_overlays_original),
+            hook_config);
 
         if (!hide_result.has_value())
         {
@@ -79,7 +88,7 @@ bool initialize_ui_overlay_hooks(uintptr_t module_base, size_t module_size)
                                      std::string(DMK::Hook::error_to_string(hide_result.error())));
         }
 
-        const uintptr_t show_addr = resolve_address(Aob::k_overlayShowCandidates, "ShowOverlays", module_base, module_size);
+        const uintptr_t show_addr = anchor_address(AnchorId::OverlayShow);
         if (show_addr == 0)
         {
             throw std::runtime_error("ShowOverlays cascade did not resolve");
@@ -88,7 +97,8 @@ bool initialize_ui_overlay_hooks(uintptr_t module_base, size_t module_size)
             "ShowOverlays",
             show_addr,
             reinterpret_cast<void *>(show_overlays_detour),
-            reinterpret_cast<void **>(&s_show_overlays_original));
+            reinterpret_cast<void **>(&s_show_overlays_original),
+            hook_config);
 
         if (!show_result.has_value())
         {

--- a/TPVCamera/src/hooks/ui_overlay_hooks.hpp
+++ b/TPVCamera/src/hooks/ui_overlay_hooks.hpp
@@ -10,19 +10,15 @@
 #ifndef TPVCAMERA_UI_OVERLAY_HOOKS_HPP
 #define TPVCAMERA_UI_OVERLAY_HOOKS_HPP
 
-#include <cstdint>
-#include <cstddef>
-
 namespace TPVCamera
 {
 
 /**
- * @brief Initialize UI overlay hooks.
- * @param module_base Base address of the target game module.
- * @param module_size Size of the target game module in bytes.
- * @return true if initialization successful, false otherwise.
+ * @brief Installs the UI overlay show/hide hooks from the pre-resolved anchors.
+ * @return true if both hooks installed, false otherwise.
+ * @note Call after resolve_all_anchors(); the hook targets are read via anchor_address().
  */
-[[nodiscard]] bool initialize_ui_overlay_hooks(uintptr_t module_base, size_t module_size);
+[[nodiscard]] bool initialize_ui_overlay_hooks();
 
 } // namespace TPVCamera
 

--- a/TPVCamera/src/overlay/dx_overlay.cpp
+++ b/TPVCamera/src/overlay/dx_overlay.cpp
@@ -404,6 +404,23 @@ DWORD WINAPI render_thread(LPVOID)
 {
     DMK::Logger &logger = DMK::Logger::get_instance();
 
+    // Make THIS overlay thread per-monitor (v2) DPI aware before any window creation or size query, so
+    // the layered overlay window, its GetClientRect/GetWindowRect reads, and the UpdateLayeredWindow
+    // composite all work in physical pixels and stay aligned on scaled (>100%) displays. This is
+    // thread-scoped, so it never changes the host game's process-wide DPI awareness (the mod is injected
+    // and must not alter the game's own rendering). Resolved dynamically because the API is Windows 10
+    // 1607+; on older systems the overlay keeps its prior behavior. The context value
+    // DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2 == (HANDLE)-4 is spelled out so the call does not depend
+    // on the SDK's WINVER gating that declaration.
+    if (const HMODULE user32 = GetModuleHandleW(L"user32.dll"))
+    {
+        using SetThreadDpiAwarenessContextFn = HANDLE(WINAPI *)(HANDLE);
+        const auto set_thread_dpi = reinterpret_cast<SetThreadDpiAwarenessContextFn>(
+            GetProcAddress(user32, "SetThreadDpiAwarenessContext"));
+        if (set_thread_dpi)
+            (void)set_thread_dpi(reinterpret_cast<HANDLE>(static_cast<INT_PTR>(-4)));
+    }
+
     s_game_hwnd = wait_for_game_window(logger);
     if (!s_game_hwnd)
         return 0;

--- a/TPVCamera/src/physics_raycast.cpp
+++ b/TPVCamera/src/physics_raycast.cpp
@@ -9,6 +9,8 @@
 
 #include <DetourModKit.hpp>
 
+#include <windows.h>
+
 #include <cmath>
 #include <cstring>
 #include <intrin.h>
@@ -39,8 +41,9 @@ bool initialize_physics_raycast(uintptr_t module_base, size_t module_size, uintp
 {
     DMK::Logger &logger = DMK::Logger::get_instance();
 
-    // The module-scoped cascade resolves the helper inside the game image or returns 0.
-    const uintptr_t ray_fn = resolve_address(Aob::k_rayWorldIntersectionCandidates, "RayWorldIntersection", module_base, module_size);
+    // The module-scoped cascade resolved the helper inside the game image (or 0 on a miss); read here
+    // from the anchor registry resolved at startup by resolve_all_anchors().
+    const uintptr_t ray_fn = anchor_address(AnchorId::RayWorldIntersection);
     if (ray_fn == 0)
     {
         logger.warning("PhysicsRaycast: RayWorldIntersection not found (game patched?); collision/aim raycast unavailable");

--- a/TPVCamera/src/presets/preset_store.cpp
+++ b/TPVCamera/src/presets/preset_store.cpp
@@ -13,10 +13,12 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <filesystem>
 #include <fstream>
 #include <memory>
 #include <optional>
 #include <string>
+#include <system_error>
 
 namespace TPVCamera::Presets
 {
@@ -338,13 +340,48 @@ void PresetStore::save()
         arr.push_back(preset_to_json(p));
     root["presets"] = std::move(arr);
 
-    std::ofstream out(m_file_path, std::ios::trunc);
-    if (!out)
+    // Atomic write: serialize to a sibling temp file, flush and close it, then rename it over the
+    // target. A crash mid-write can only ever leave the temp truncated, never the live file, so the
+    // user's preset set survives (load() falls back to factory defaults only on a genuinely corrupt
+    // file, and an in-place truncation would have looked exactly like one). std::filesystem::rename
+    // replaces the destination on Windows (MoveFileEx semantics), so the swap is atomic on one volume.
+    const std::string temp_path = m_file_path + ".tmp";
+    try
     {
-        logger.warning("Preset save failed: cannot open {}", m_file_path);
+        std::ofstream out(temp_path, std::ios::trunc);
+        if (!out)
+        {
+            logger.warning("Preset save failed: cannot open {}", temp_path);
+            return;
+        }
+        // dump(2) can throw (e.g. nlohmann type_error.316 on invalid UTF-8 in a preset string); the catch
+        // below treats it like a write failure so the live preset file is never disturbed.
+        out << root.dump(2);
+        out.flush();
+        if (!out)
+        {
+            logger.warning("Preset save failed: write error on {}", temp_path);
+            return;
+        }
+    } // close the stream so the rename sees a fully flushed file
+    catch (const std::exception &e)
+    {
+        logger.warning("Preset save failed: serialization error ({})", e.what());
+        std::error_code remove_ec;
+        std::filesystem::remove(temp_path, remove_ec); // do not leave a partial temp behind
         return;
     }
-    out << root.dump(2);
+
+    std::error_code rename_ec;
+    std::filesystem::rename(temp_path, m_file_path, rename_ec);
+    if (rename_ec)
+    {
+        logger.warning("Preset save failed: cannot replace {} ({})", m_file_path, rename_ec.message());
+        std::error_code remove_ec;
+        std::filesystem::remove(temp_path, remove_ec); // best-effort: do not leave the temp behind
+        return;
+    }
+
     m_dirty = false;
     logger.info("Presets saved to {}", m_file_path);
 }

--- a/TPVCamera/src/tpv_camera.cpp
+++ b/TPVCamera/src/tpv_camera.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "tpv_camera.hpp"
+#include "aob_resolver.hpp"
 #include "config.hpp"
 #include "constants.hpp"
 #include "global_state.hpp"
@@ -135,30 +136,36 @@ static bool initialize_hooks()
     DMK::Logger &logger = DMK::Logger::get_instance();
     const ModuleInfo &mod = module_info();
 
+    // Resolve every game-image anchor in one parallel pass, confined to the WHGame.dll image range,
+    // before any module init reads its target. resolve_all_anchors() logs a per-anchor status and a
+    // quality summary; each init below reads its address via anchor_address(), and a mandatory anchor
+    // that did not resolve fails the init that needs it.
+    resolve_all_anchors(mod.base, mod.size);
+
     // Built-in view flag, read by the camera gate to avoid stacking on the engine's own TPV.
-    if (!initialize_game_interface(mod.base, mod.size))
+    if (!initialize_game_interface())
     {
         logger.warning("Game interface initialization failed - built-in TPV detection disabled");
     }
 
-    if (!initialize_ui_menu_hooks(mod.base, mod.size))
+    if (!initialize_ui_menu_hooks())
     {
         logger.warning("UI Menu hooks initialization failed - menu suppression disabled");
     }
 
-    if (!initialize_ui_overlay_hooks(mod.base, mod.size))
+    if (!initialize_ui_overlay_hooks())
     {
         logger.warning("UI Overlay hooks initialization failed - overlay suppression disabled");
     }
 
-    if (!initialize_interaction_hook(mod.base, mod.size))
+    if (!initialize_interaction_hook())
     {
         logger.warning("Interaction hook initialization failed - camera-space interaction disabled");
     }
 
     // Device-agnostic movement intent for the orbit move-detection. Best-effort: a miss falls back to
     // body-position speed, so the camera still works without it.
-    if (!initialize_player_onaction_hook(mod.base, mod.size))
+    if (!initialize_player_onaction_hook())
     {
         logger.warning("Player OnAction hook initialization failed - orbit move-detection uses body speed");
     }
@@ -400,6 +407,12 @@ void shutdown()
 {
     DMK::Logger &logger = DMK::Logger::get_instance();
     logger.info("Shutdown: starting teardown");
+
+    // One-line health snapshot before teardown: hook population + intentional-leak counters (DMK 3.8.0
+    // diagnostics). The hooks are still installed here -- DMK_Shutdown() removes them after this returns.
+    const DMK::Diagnostics::Snapshot diag = DMK::Diagnostics::collect(DMK::HookManager::get_instance());
+    logger.info("Diagnostics: {} hooks ({} active, {} disabled), {} intentional leaks", diag.hooks_total,
+                diag.hooks_active, diag.hooks_disabled, diag.total_intentional_leaks);
 
     // Stop the INI watcher first so no reload setter runs during teardown.
     DMK::Config::disable_auto_reload();


### PR DESCRIPTION
## Summary
Upgrades TPVCamera to DetourModKit 3.8.0 and adopts its new resilience and diagnostics APIs, alongside a set of correctness fixes. No new user-facing settings or hotkeys.

## Changes
- Bumps the vendored DetourModKit submodule to v3.8.0.
- Migrates the AOB cascades to the declarative anchor registry, resolved in one parallel pass at startup with a quality summary.
- Installs all inline hooks with a fail-closed prologue policy so a mis-resolved or foreign-stubbed entry is refused rather than patched blindly.
- Collapses the camera and minigame pointer-chain walks onto seh_read_chain and makes the global context pointer atomic.
- Fixes a torn interaction-pose read with a seqlock, overlay blur and misalignment on displays scaled above 100%, non-atomic preset saving, and unguarded eye-pose reads.
- Logs a one-line diagnostics snapshot at shutdown and switches the release build to /O2.
