### PR TITLE
feat(tpvcamera): self-heal pointer-chain offsets across game patches

### DIFF
--- a/TPVCamera/CMakeLists.txt
+++ b/TPVCamera/CMakeLists.txt
@@ -111,6 +111,7 @@ set(COMMON_SOURCES
   src/game_interface.cpp
   src/game_state.cpp
   src/global_state.cpp
+  src/offset_heal.cpp
   src/physics_raycast.cpp
   src/tpv_camera.cpp
   src/version.cpp

--- a/TPVCamera/README.md
+++ b/TPVCamera/README.md
@@ -252,6 +252,17 @@ fallback), and engine object types are matched by their MSVC RTTI names rather t
 addresses. The cascade signatures follow DetourModKit's
 [AOB signature guide](https://github.com/tkhquang/DetourModKit/blob/main/docs/misc/aob-signatures.md).
 
+The AOB cascades resolve struct base addresses; a self-healing offset layer (`src/offset_heal.hpp`)
+covers the field offsets walked inside those structs. A game patch that inserts or removes a member
+shifts every field after it, so each in-scope offset is keyed to the MSVC RTTI name of the object its
+slot points at, and DetourModKit's reverse-RTTI self-heal (`rtti_dissect.hpp`) scans a small window
+around the nominal offset for the slot that still resolves to that type. The recovery runs once per
+session the first time a live, RTTI-validated player and context resolve (never per frame); the
+per-frame chains then read the cached offset. The look controller, whose pointee has no RTTI of its
+own, is bracketed by its two RTTI-typed neighbours and only moves when both agree on one shift.
+Everything is fail-closed: an offset the heal cannot recover stays at its built-in value, so the mod
+degrades to its previous behaviour rather than reading the wrong memory.
+
 ## Credits
 
 - [ThirteenAG](https://github.com/ThirteenAG) - for the Ultimate ASI Loader

--- a/TPVCamera/build/template/KCD2_TPVCamera.ini
+++ b/TPVCamera/build/template/KCD2_TPVCamera.ini
@@ -42,6 +42,13 @@ AutoEnableTPV = true
 ; (takes effect once the third-person view is active). Default: false
 AutoEnableOrbit = false
 
+; ===== ADVANCED =====
+[Advanced]
+; Internal tuning. Leave at the default unless instructed otherwise.
+; SelfHealWindow: byte radius the mod scans to re-locate its internal offsets after a
+; game update; raise only if a patch moves things further than the default. Default: 256
+SelfHealWindow = 256
+
 ; ===== CAMERA FRAMING =====
 [Camera]
 ; NOTE: the camera framing itself -- follow distance, shoulder offsets, eye

--- a/TPVCamera/docs/NEXT_CHANGELOG.md
+++ b/TPVCamera/docs/NEXT_CHANGELOG.md
@@ -3,5 +3,6 @@
 - Updated the bundled modding toolkit (DetourModKit) to the latest version (v3.8.0)
 - Fixed the preset overlay looking blurry or misaligned on displays scaled above 100%
 - Saved camera presets can no longer be lost if the game closes while they are being written
-- Made the camera more resilient to future game updates and safer to load alongside other mods
+- The third-person camera now automatically adapts to many game updates that move data around internally, so a common patch no longer breaks it before the mod is updated
+- Stays safe to load alongside other mods, and falls back to its previous behaviour if a game update changes too much
 - Various under-the-hood stability and reliability fixes

--- a/TPVCamera/src/aob_resolver.cpp
+++ b/TPVCamera/src/aob_resolver.cpp
@@ -82,7 +82,9 @@ void resolve_all_anchors(std::uintptr_t module_base, std::size_t module_size)
         if (entry.status == DMK::Anchors::AnchorStatus::Resolved)
         {
             s_resolved_addresses[i] = static_cast<std::uintptr_t>(entry.value);
-            logger.info("Anchor {} -> {}", entry.label, DMK::Format::format_address(s_resolved_addresses[i]));
+            // Per-anchor address is for RE / external tooling, not routine status, so keep it at Debug; the
+            // one-line quality summary below is the default-level health check, and a failure still warns.
+            logger.debug("Anchor {} -> {}", entry.label, DMK::Format::format_address(s_resolved_addresses[i]));
         }
         else
         {

--- a/TPVCamera/src/config.cpp
+++ b/TPVCamera/src/config.cpp
@@ -51,6 +51,9 @@ void register_config_items()
     DMK::Config::register_atomic<bool>("Settings", "AutoEnableTPV", "Auto Enable TPV", s.auto_enable_tpv, true);
     DMK::Config::register_atomic<bool>("Settings", "AutoEnableOrbit", "Auto Enable Orbit", s.auto_enable_orbit, false);
 
+    // Advanced: RTTI self-heal search radius (see offset_heal.cpp). Not for normal users.
+    DMK::Config::register_atomic<int>("Advanced", "SelfHealWindow", "Self Heal Window", s.self_heal_window, 0x100);
+
     // Camera framing. The follow distance, offsets, eye height, aim focus, follow yaw/pitch, the orbit
     // tuning, and the per-preset collision values are all OWNED BY PRESETS (in the shipped presets JSON,
     // applied to the live atomics each frame), so they are NOT INI settings -- tune them in the overlay.

--- a/TPVCamera/src/config.hpp
+++ b/TPVCamera/src/config.hpp
@@ -142,6 +142,12 @@ namespace TPVCamera
         // Start-of-session auto-enable flags, read ONCE during init(). Disabled by default.
         std::atomic<bool> auto_enable_tpv{false};   // enter third-person automatically on game start
         std::atomic<bool> auto_enable_orbit{false}; // engage free-look orbit automatically on game start
+
+        // Advanced. Per-side search radius (bytes) the RTTI self-heal scans around each nominal offset to
+        // recover a field after a game patch shifts the struct layout (see offset_heal.cpp). Read once when
+        // the heal runs (not a hot path); clamped to the DMK maximum. Larger tolerates a bigger insertion at
+        // a slightly higher risk of a wrong heal onto a same-typed neighbour. Not for normal users to touch.
+        std::atomic<int> self_heal_window{0x100};
     };
 
     /** @brief Returns the process-wide live (atomic) settings. */

--- a/TPVCamera/src/constants.hpp
+++ b/TPVCamera/src/constants.hpp
@@ -97,6 +97,13 @@ namespace Constants
     constexpr ptrdiff_t CCRYACTION_ACTIONGAME_OFFSET = 0x88;
     constexpr ptrdiff_t CACTIONGAME_LOCAL_ACTOR_OFFSET = 0xA40;
     constexpr ptrdiff_t C_PLAYER_LOOK_CONTROLLER_OFFSET = 0x238;
+    // The look-controller pointee is a non-polymorphic struct with no RTTI, so the self-heal layer cannot
+    // match it by type directly. C_HitDeathReactions is the RTTI-typed member at the immediately adjacent
+    // qword (C_Player + 0x240); pairing it with the entity pointer (C_Player + 0x38) brackets the
+    // look-controller slot so its offset rides a uniform layout shift only when both straddling neighbours
+    // agree on one delta, and stays nominal otherwise (fail-closed). See offset_heal.cpp.
+    constexpr ptrdiff_t C_PLAYER_HIT_DEATH_REACTIONS_OFFSET = 0x240;
+    constexpr const char *C_HIT_DEATH_REACTIONS_RTTI_NAME = ".?AVC_HitDeathReactions@entitymodule@wh@@";
     constexpr ptrdiff_t LOOK_CONTROLLER_PITCH_OFFSET = 0x8;   // scalar look pitch (radians, 0 = level)
     constexpr ptrdiff_t LOOK_CONTROLLER_PITCH2_OFFSET = 0x48; // synchronized pitch copy
     // Scalar look yaw (radians; horizontal forward = (-sin yaw, cos yaw)), with a synchronized copy.
@@ -119,7 +126,12 @@ namespace Constants
     //   then write animchar+ANIMCHAR_OVERRIDE_ROT_ACTIVE_OFFSET = 1 and the world quat (XYZW) at
     //   animchar+ANIMCHAR_OVERRIDE_ROT_QUAT_OFFSET.
     constexpr ptrdiff_t C_PLAYER_ENTITY_OFFSET = 0x38; // C_Player -> CEntity (resolve fresh each frame)
+    // RTTI type-descriptor name of CEntity, the self-heal anchor for the entity pointer. CEntity is a
+    // stable engine base type (per the self-heal guidance to key on a base, not a game-specific subtype).
+    constexpr const char *C_ENTITY_RTTI_NAME = ".?AVCEntity@@";
     constexpr ptrdiff_t C_PLAYER_ANIMATED_HUMAN_OFFSET = 0x268;
+    // RTTI type-descriptor name of C_AnimatedHuman, the self-heal anchor for the animated-human pointer.
+    constexpr const char *C_ANIMATED_HUMAN_RTTI_NAME = ".?AVC_AnimatedHuman@animationmodule@wh@@";
     constexpr ptrdiff_t ANIMATED_HUMAN_ANIMCHAR_OFFSET = 0x20;
     // RTTI type-descriptor name of CAnimatedCharacter, used to validate the resolved animchar.
     constexpr const char *ANIMATED_CHARACTER_RTTI_NAME = ".?AVCAnimatedCharacter@@";
@@ -319,6 +331,8 @@ namespace Constants
     // Global-context -> camera-manager pointer. The manager is the root the game-state detection
     // walks to read the active camera (see OFFSET_ACTIVE_CAMERA below and game_state.cpp).
     constexpr ptrdiff_t OFFSET_MANAGER_PTR_STORAGE = 0x38; // Global context to camera manager
+    // RTTI type-descriptor name of the camera manager, the self-heal anchor for OFFSET_MANAGER_PTR_STORAGE.
+    constexpr const char *C_CAMERA_MANAGER_RTTI_NAME = ".?AVC_CameraManager@game@wh@@";
 
     // --- Game-state detection (see game_state.cpp) ---
     // Active-camera pointer on the wh::game::C_CameraManager (the same manager reached via
@@ -352,6 +366,8 @@ namespace Constants
     // OFFSET_MINIGAME_NODE_VALUE; the minigame's owning C_Human/C_Player is at OFFSET_MINIGAME_OWNER.
     // The concrete minigame's RTTI then identifies WHICH minigame (see the names below).
     constexpr ptrdiff_t OFFSET_MINIGAME_SUBSYSTEM = 0x128; // global context -> minigame subsystem pointer
+    // RTTI type-descriptor name of the minigame subsystem, the self-heal anchor for OFFSET_MINIGAME_SUBSYSTEM.
+    constexpr const char *C_PLAYER_MODULE_RTTI_NAME = ".?AVC_PlayerModule@playermodule@wh@@";
     constexpr ptrdiff_t OFFSET_MINIGAME_MANAGER = 0x18;    // subsystem -> C_MinigameManager (getter inlined)
     constexpr ptrdiff_t OFFSET_MINIGAME_MAP_HEAD = 0x20;   // manager -> minigame-map sentinel node pointer
     constexpr ptrdiff_t OFFSET_MINIGAME_NODE_NEXT = 0x00;  // list node -> next node (sentinel terminates)

--- a/TPVCamera/src/game_state.cpp
+++ b/TPVCamera/src/game_state.cpp
@@ -11,6 +11,7 @@
 #include "game_state.hpp"
 #include "constants.hpp"
 #include "global_state.hpp"
+#include "offset_heal.hpp"
 #include "hooks/ui_menu_hooks.hpp"
 
 #include <DetourModKit.hpp>
@@ -61,10 +62,11 @@ namespace
 
 /**
  * @brief Resolves the active camera and classifies it, returning 0 on any failed read.
- * @details Walks g_global_context -> camera manager (OFFSET_MANAGER_PTR_STORAGE) -> active camera
- *          (OFFSET_ACTIVE_CAMERA) -> vtable, each link SEH-guarded and screened as a plausible
- *          user-space pointer. The manager is the same wh::game::C_CameraManager the built-in TPV
- *          flag is read from, so the chain reuses the already-resolved context pointer storage.
+ * @details Dereferences the global-context slot to the context object first (so the self-heal can scan the
+ *          anchored base), then once the world is live heals the context member offsets one-shot, then walks
+ *          context -> camera manager (self-healed OFFSET_MANAGER_PTR_STORAGE) -> active camera
+ *          (OFFSET_ACTIVE_CAMERA) -> vtable, each link SEH-guarded and screened as a plausible user-space
+ *          pointer. The manager is the same wh::game::C_CameraManager the built-in TPV flag is read from.
  */
 [[nodiscard]] uint32_t poll_active_camera_state() noexcept
 {
@@ -73,13 +75,25 @@ namespace
     {
         return 0;
     }
-    // One guarded walk: g_global_context -> camera manager (OFFSET_MANAGER_PTR_STORAGE) -> active camera
-    // (OFFSET_ACTIVE_CAMERA) -> vtable. seh_read_chain screens every intermediate link with
+    // Resolve the context object first so the self-heal can run against it. Gating the heal on the world
+    // being live (rather than on the manager slot being populated) keeps a camera-manager OFFSET drift
+    // recoverable: the heal scans the anchored context base, never navigating through the offset it heals.
+    const auto context = DMK::Memory::seh_read<uintptr_t>(reinterpret_cast<uintptr_t>(context_slot));
+    if (!context || !DMK::Memory::plausible_userspace_ptr(*context))
+    {
+        return 0;
+    }
+    if (game_world_ready().load(std::memory_order_relaxed))
+    {
+        heal_context_offsets(*context);
+    }
+    // One guarded walk: context object -> camera manager (self-healed OFFSET_MANAGER_PTR_STORAGE) -> active
+    // camera (OFFSET_ACTIVE_CAMERA) -> vtable. seh_read_chain screens every intermediate link with
     // plausible_userspace_ptr under a single fault guard; the terminal vtable value it returns is not
     // range-checked by the chain, so it is screened here to match the previous per-hop walk.
     const auto vtable = DMK::Memory::seh_read_chain<uintptr_t>(
-        reinterpret_cast<uintptr_t>(context_slot),
-        {0, Constants::OFFSET_MANAGER_PTR_STORAGE, Constants::OFFSET_ACTIVE_CAMERA, 0});
+        *context, {runtime_offsets().context_manager.load(std::memory_order_relaxed),
+                   Constants::OFFSET_ACTIVE_CAMERA, 0});
     if (!vtable || !DMK::Memory::plausible_userspace_ptr(*vtable))
     {
         return 0;
@@ -144,8 +158,8 @@ namespace
     // head's next back to the head itself, so the begin read below is deliberately NOT plausibility-screened.
     const auto head = DMK::Memory::seh_read_chain<uintptr_t>(
         reinterpret_cast<uintptr_t>(context_slot),
-        {0, Constants::OFFSET_MINIGAME_SUBSYSTEM, Constants::OFFSET_MINIGAME_MANAGER,
-         Constants::OFFSET_MINIGAME_MAP_HEAD});
+        {0, runtime_offsets().context_minigame_subsystem.load(std::memory_order_relaxed),
+         Constants::OFFSET_MINIGAME_MANAGER, Constants::OFFSET_MINIGAME_MAP_HEAD});
     if (!head || !DMK::Memory::plausible_userspace_ptr(*head))
     {
         return 0;
@@ -212,7 +226,9 @@ namespace
  */
 [[nodiscard]] bool poll_missile_aiming(uintptr_t c_player) noexcept
 {
-    const auto vtable = DMK::Memory::seh_read<uintptr_t>(c_player + Constants::C_PLAYER_MISSILE_CONTROLLER_OFFSET);
+    const std::ptrdiff_t missile_offset =
+        runtime_offsets().c_player_missile_controller.load(std::memory_order_relaxed);
+    const auto vtable = DMK::Memory::seh_read<uintptr_t>(c_player + missile_offset);
     if (!vtable || !DMK::Memory::plausible_userspace_ptr(*vtable))
     {
         return false;
@@ -233,8 +249,8 @@ namespace
     // The aim flag is a single BYTE: the surrounding bytes pack a separate "weapon in hand" flag,
     // so reading a dword would also fire when the weapon is merely drawn (in hand not aiming = 0,
     // raised/aiming = 1).
-    const auto aim_flag = DMK::Memory::seh_read<uint8_t>(
-        c_player + Constants::C_PLAYER_MISSILE_CONTROLLER_OFFSET + Constants::MISSILE_CONTROLLER_AIM_FLAG_OFFSET);
+    const auto aim_flag =
+        DMK::Memory::seh_read<uint8_t>(c_player + missile_offset + Constants::MISSILE_CONTROLLER_AIM_FLAG_OFFSET);
     return aim_flag && *aim_flag != 0;
 }
 
@@ -256,7 +272,8 @@ namespace
  */
 [[nodiscard]] uint32_t poll_stance(uintptr_t c_player) noexcept
 {
-    const auto actor_model = DMK::Memory::seh_read<uintptr_t>(c_player + Constants::C_PLAYER_ACTOR_MODEL_OFFSET);
+    const auto actor_model = DMK::Memory::seh_read<uintptr_t>(
+        c_player + runtime_offsets().c_player_actor_model.load(std::memory_order_relaxed));
     if (!actor_model || !DMK::Memory::plausible_userspace_ptr(*actor_model))
     {
         return 0u;

--- a/TPVCamera/src/hooks/camera_hook.cpp
+++ b/TPVCamera/src/hooks/camera_hook.cpp
@@ -30,6 +30,7 @@
 #include "global_state.hpp"
 #include "game_state.hpp"
 #include "game_structures.hpp"
+#include "offset_heal.hpp"
 #include "math_utils.hpp"
 #include "physics_raycast.hpp"
 #include "hooks/ui_menu_hooks.hpp"
@@ -45,6 +46,7 @@
 #include <chrono>
 #include <cmath>
 #include <cstdint>
+#include <optional>
 #include <stdexcept>
 #include <string>
 
@@ -237,28 +239,70 @@ static uintptr_t resolve_c_player()
     {
         return 0;
     }
-    const auto c_player =
-        DMK::Memory::seh_read<uintptr_t>(*p_action_game + Constants::CACTIONGAME_LOCAL_ACTOR_OFFSET);
-    if (!c_player || !DMK::Memory::plausible_userspace_ptr(*c_player))
+
+    // Read the local actor through the self-healed CActionGame offset, then confirm it is a real C_Player
+    // by its vtable. C_Player is found THROUGH this offset, so the offset cannot be healed from a resolved
+    // C_Player; instead, when the cached slot holds a populated object that is NOT a C_Player (the
+    // signature of a CActionGame layout drift), attempt a bounded recovery scan and re-read. The nominal
+    // slot is probed first inside the heal, so an undrifted build never scans.
+    RuntimeOffsets &offsets = runtime_offsets();
+    auto player = DMK::Memory::seh_read<uintptr_t>(
+        *p_action_game + offsets.cactiongame_local_actor.load(std::memory_order_relaxed));
+    const auto is_c_player = [](const std::optional<uintptr_t> &candidate) {
+        if (!candidate || !DMK::Memory::plausible_userspace_ptr(*candidate))
+        {
+            return false;
+        }
+        const auto vt = DMK::Memory::seh_read<uintptr_t>(*candidate);
+        return vt.has_value() && DMK::Rtti::vtable_is_type(*vt, Constants::C_PLAYER_RTTI_NAME);
+    };
+    bool player_valid = is_c_player(player);
+    if (!player_valid && player && DMK::Memory::plausible_userspace_ptr(*player))
+    {
+        // The cached slot holds a populated object that is NOT a C_Player: the signature of a CActionGame
+        // layout drift. Recover the offset by scanning CActionGame for the C_Player slot, then re-read and
+        // re-validate. A successful recovery updates the cache, so the read above succeeds on later frames
+        // and this branch stops being entered (the natural stop). The scan is RATE-LIMITED to a fixed frame
+        // interval rather than capped by a fixed number of attempts: the heal contract forbids scanning
+        // every frame (it is syscall-heavy), but a hard attempt cap could be exhausted by a slow save/level
+        // load, where the real player may not be seated until many seconds after this slot first reads
+        // populated-but-wrong, permanently disabling recovery before the player even exists. An interval
+        // never gives up, so it keeps retrying until the player appears; on a truly unrecoverable drift it
+        // settles into a cheap periodic scan, not a per-frame one. The first entered frame scans immediately
+        // (counter starts at 0), so an undrifted-with-real-drift build recovers on the first opportunity.
+        constexpr int k_local_actor_retry_interval_frames = 30; // about 0.5s at 60 FPS between scans
+        static int s_frames_until_retry = 0;
+        if (s_frames_until_retry > 0)
+        {
+            --s_frames_until_retry;
+        }
+        else
+        {
+            s_frames_until_retry = k_local_actor_retry_interval_frames;
+            const std::ptrdiff_t healed = heal_local_actor_offset(*p_action_game);
+            player = DMK::Memory::seh_read<uintptr_t>(*p_action_game + healed);
+            player_valid = is_c_player(player);
+        }
+    }
+    if (!player_valid)
     {
         return 0;
     }
-    const auto vt = DMK::Memory::seh_read<uintptr_t>(*c_player);
-    if (!vt || !DMK::Rtti::vtable_is_type(*vt, Constants::C_PLAYER_RTTI_NAME))
-    {
-        return 0;
-    }
+
+    // A real C_Player is in hand: heal its rooted offsets once (one-shot internally), so the per-frame aim
+    // and body-turn walks read the recovered offsets on a drifted build.
+    heal_player_offsets(*player);
 
     // Log the resolved C_Player and cached CCryAction only when the player pointer CHANGES (once on first
     // resolve, and again after a reload / new player) so the address is available for external tooling
     // without flooding the log.
     {
         static uintptr_t s_logged_player{0};
-        if (*c_player != s_logged_player)
+        if (*player != s_logged_player)
         {
-            s_logged_player = *c_player;
+            s_logged_player = *player;
             DMK::Logger::get_instance().debug("C_Player resolved={} (CCryAction={})",
-                                              DMK::Format::format_address(*c_player),
+                                              DMK::Format::format_address(*player),
                                               DMK::Format::format_address(s_cry_action));
         }
     }
@@ -267,7 +311,7 @@ static uintptr_t resolve_c_player()
     // wait on this so it never sizes itself to the transient loading window.
     game_world_ready().store(true, std::memory_order_relaxed);
 
-    return *c_player;
+    return *player;
 }
 
 /**
@@ -330,8 +374,8 @@ static void apply_orbit_aim_control_impl(float pitch_ease, bool set_yaw, float y
     {
         return;
     }
-    const auto c_player =
-        DMK::Memory::seh_read<uintptr_t>(*p_action_game + Constants::CACTIONGAME_LOCAL_ACTOR_OFFSET);
+    const auto c_player = DMK::Memory::seh_read<uintptr_t>(
+        *p_action_game + runtime_offsets().cactiongame_local_actor.load(std::memory_order_relaxed));
     if (!c_player || !DMK::Memory::plausible_userspace_ptr(*c_player))
     {
         return;
@@ -342,8 +386,8 @@ static void apply_orbit_aim_control_impl(float pitch_ease, bool set_yaw, float y
     {
         return;
     }
-    const auto controller =
-        DMK::Memory::seh_read<uintptr_t>(*c_player + Constants::C_PLAYER_LOOK_CONTROLLER_OFFSET);
+    const auto controller = DMK::Memory::seh_read<uintptr_t>(
+        *c_player + runtime_offsets().c_player_look_controller.load(std::memory_order_relaxed));
     if (!controller || !DMK::Memory::plausible_userspace_ptr(*controller))
     {
         return;
@@ -421,14 +465,15 @@ static void apply_orbit_body_turn_impl(float target_yaw)
 
     // C_Player -> C_AnimatedHuman (+0x268) -> CAnimatedCharacter (+0x20). Validate the animchar vtable
     // before touching its override fields; a mismatch means the layout drifted, so skip this frame.
-    const auto animated_human =
-        DMK::Memory::seh_read<uintptr_t>(c_player + Constants::C_PLAYER_ANIMATED_HUMAN_OFFSET);
+    const RuntimeOffsets &offsets = runtime_offsets();
+    const auto animated_human = DMK::Memory::seh_read<uintptr_t>(
+        c_player + offsets.c_player_animated_human.load(std::memory_order_relaxed));
     if (!animated_human || !DMK::Memory::plausible_userspace_ptr(*animated_human))
     {
         return;
     }
-    const auto anim_char =
-        DMK::Memory::seh_read<uintptr_t>(*animated_human + Constants::ANIMATED_HUMAN_ANIMCHAR_OFFSET);
+    const auto anim_char = DMK::Memory::seh_read<uintptr_t>(
+        *animated_human + offsets.animated_human_animchar.load(std::memory_order_relaxed));
     if (!anim_char || !DMK::Memory::plausible_userspace_ptr(*anim_char))
     {
         return;
@@ -609,7 +654,8 @@ static void offset_game_view_camera(uintptr_t camera, uintptr_t cview, uintptr_t
         uintptr_t entity_addr = 0;
         if (c_player != 0)
         {
-            const auto ent = DMK::Memory::seh_read<uintptr_t>(c_player + Constants::C_PLAYER_ENTITY_OFFSET);
+            const auto ent = DMK::Memory::seh_read<uintptr_t>(
+                c_player + runtime_offsets().c_player_entity.load(std::memory_order_relaxed));
             if (ent && DMK::Memory::plausible_userspace_ptr(*ent))
             {
                 entity_addr = *ent;

--- a/TPVCamera/src/offset_heal.cpp
+++ b/TPVCamera/src/offset_heal.cpp
@@ -1,0 +1,300 @@
+/**
+ * @file offset_heal.cpp
+ * @brief Landmark tables and heal logic backing the runtime offset cache.
+ */
+
+#include "offset_heal.hpp"
+#include "config.hpp"
+#include "constants.hpp"
+
+#include <DetourModKit.hpp>
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <string_view>
+
+namespace TPVCamera
+{
+
+namespace
+{
+
+// Search radius per side for every heal, in bytes (applied to both the heal_landmark windows and the
+// solve_fingerprint span). This is a correctness trade-off, NOT "bigger is safer": too small misses a large
+// insertion but fails CLOSED (keeps the nominal offset = the current hardcoded behaviour, never a crash); too
+// large would, for an INDEPENDENT single-landmark scan, risk a confident WRONG heal onto a same-typed
+// neighbour. That decoy risk is why the window can be this wide: the one common-typed member
+// (entity/CEntity) is recovered via the corroborated bracket (k_player_top_bracket), not an independent
+// scan, so EVERY remaining independent heal keys on a type that is UNIQUE within its parent struct, where a
+// wide window cannot find a decoy; the bracket itself rejects decoys structurally (one delta must satisfy
+// two anchors). The default 0x100 covers a 32-qword insertion before a field while staying far below
+// MAX_HEAL_WINDOW (4096), so the init-time probe count stays bounded. It is exposed in the INI
+// ([Advanced] SelfHealWindow) for the rare case a real patch shifts a field further than the default.
+constexpr std::size_t k_heal_window_default = 0x100;
+
+// Resolved search radius: the INI value (read once when the heal runs, not a hot path), clamped to the DMK
+// maximum; a non-positive or unset value falls back to the default. A wider window also widens the
+// uncorroborated entity fallback's decoy exposure, which is the deliberate cost the INI knob trades for
+// reach.
+[[nodiscard]] std::size_t heal_window() noexcept
+{
+    const int configured = settings().self_heal_window.load(std::memory_order_relaxed);
+    if (configured <= 0)
+    {
+        return k_heal_window_default;
+    }
+    return std::min(static_cast<std::size_t>(configured), DMK::Rtti::MAX_HEAL_WINDOW);
+}
+
+// Self-heal landmarks: "at this nominal offset within the struct there is a slot referring to an object of
+// this mangled type." Each is keyed on a type that is stable across patches (an engine/base type or an
+// already-trusted concrete type), per the rtti_dissect guidance. base is filled at call time. The
+// indirection records the slot SHAPE: every member here is a pointer-to-object EXCEPT the missile
+// controller, which is constructed in-place inside C_Player (its first qword is the vtable), so its slot is
+// a direct object base.
+constexpr DMK::Rtti::Landmark k_entity_lm{
+    .nominal_offset = Constants::C_PLAYER_ENTITY_OFFSET,
+    .expected_mangled = Constants::C_ENTITY_RTTI_NAME,
+    .indirection = DMK::Rtti::Indirection::PointerToObject};
+constexpr DMK::Rtti::Landmark k_animhuman_lm{
+    .nominal_offset = Constants::C_PLAYER_ANIMATED_HUMAN_OFFSET,
+    .expected_mangled = Constants::C_ANIMATED_HUMAN_RTTI_NAME,
+    .indirection = DMK::Rtti::Indirection::PointerToObject};
+constexpr DMK::Rtti::Landmark k_actormodel_lm{
+    .nominal_offset = Constants::C_PLAYER_ACTOR_MODEL_OFFSET,
+    .expected_mangled = Constants::C_ACTOR_MODEL_RTTI_NAME,
+    .indirection = DMK::Rtti::Indirection::PointerToObject};
+constexpr DMK::Rtti::Landmark k_missile_lm{
+    .nominal_offset = Constants::C_PLAYER_MISSILE_CONTROLLER_OFFSET,
+    .expected_mangled = Constants::C_MISSILE_CONTROLLER_RTTI_NAME,
+    .indirection = DMK::Rtti::Indirection::ObjectBase}; // embedded object, not a pointer
+constexpr DMK::Rtti::Landmark k_animchar_lm{
+    .nominal_offset = Constants::ANIMATED_HUMAN_ANIMCHAR_OFFSET,
+    .expected_mangled = Constants::ANIMATED_CHARACTER_RTTI_NAME,
+    .indirection = DMK::Rtti::Indirection::PointerToObject};
+constexpr DMK::Rtti::Landmark k_localactor_lm{
+    .nominal_offset = Constants::CACTIONGAME_LOCAL_ACTOR_OFFSET,
+    .expected_mangled = Constants::C_PLAYER_RTTI_NAME,
+    .indirection = DMK::Rtti::Indirection::PointerToObject};
+constexpr DMK::Rtti::Landmark k_manager_lm{
+    .nominal_offset = Constants::OFFSET_MANAGER_PTR_STORAGE,
+    .expected_mangled = Constants::C_CAMERA_MANAGER_RTTI_NAME,
+    .indirection = DMK::Rtti::Indirection::PointerToObject};
+constexpr DMK::Rtti::Landmark k_minigame_subsystem_lm{
+    .nominal_offset = Constants::OFFSET_MINIGAME_SUBSYSTEM,
+    .expected_mangled = Constants::C_PLAYER_MODULE_RTTI_NAME,
+    .indirection = DMK::Rtti::Indirection::PointerToObject};
+
+constexpr DMK::Rtti::Landmark k_hitdeath_lm{
+    .nominal_offset = Constants::C_PLAYER_HIT_DEATH_REACTIONS_OFFSET,
+    .expected_mangled = Constants::C_HIT_DEATH_REACTIONS_RTTI_NAME,
+    .indirection = DMK::Rtti::Indirection::PointerToObject};
+
+// Corroborated top-of-struct bracket. It recovers TWO members' offsets from one uniform delta that BOTH
+// straddling RTTI anchors agree on:
+//   - the look controller, whose own pointee is a non-polymorphic struct with NO RTTI, so it cannot be
+//     matched by type at all; and
+//   - the entity pointer, whose pointee type (CEntity) is COMMON, so an independent window scan could heal
+//     onto the wrong same-typed neighbour. Requiring entity and HitDeathReactions to agree on one delta
+//     rejects that decoy STRUCTURALLY, which is what lets the search window be widened safely.
+// Both anchors are required (the Landmark default), so the agreement is genuine. entity is the TOPMOST
+// anchor: a shift that moves it moves HitDeathReactions equally (the bracket then succeeds), and a shift
+// below entity leaves it at nominal (correct); a net insertion BETWEEN the anchors makes them disagree, so
+// solve_fingerprint returns NoMatch and both offsets stay nominal (fail-closed). Built from the named
+// landmarks so entity has a single definition shared with nothing else.
+constexpr std::array<DMK::Rtti::Landmark, 2> k_player_top_bracket{{k_entity_lm, k_hitdeath_lm}};
+
+/**
+ * @brief Emits one process-wide Warning the first time any offset is found to have drifted.
+ * @details The per-landmark "moved" lines are logged at Info (a recovery is a success, not a fault). This
+ *          single Warning is the actionable headline: a drift means a game update reshaped a struct, and
+ *          while the RTTI-typed POINTER offsets here auto-recovered, the NON-healable scalar/flag offsets in
+ *          the same structs (look pitch/yaw, stance, the missile aim byte, hide-head, the CryEngine struct
+ *          layouts) cannot self-heal and silently ride the same shift, so they need a human to re-verify.
+ *          CAS one-shot, and callers invoke it BEFORE the first moved Info line, so it fires exactly once and
+ *          reads as a header above the per-offset lines rather than interleaving with them.
+ */
+void warn_layout_drift_once() noexcept
+{
+    static std::atomic<bool> s_warned{false};
+    bool expected = false;
+    if (s_warned.compare_exchange_strong(expected, true, std::memory_order_relaxed))
+    {
+        DMK::Logger::get_instance().warning(
+            "Self-heal: layout drifted; pointer offsets recovered (below). Re-verify non-healable scalars "
+            "(pitch/yaw, stance, aim flag).");
+    }
+}
+
+/**
+ * @brief Heals one landmark from a resolved base and writes its cache slot, logging the outcome.
+ * @details Copies the constexpr template, fills its base, and runs heal_landmark. On a resolve the cache
+ *          slot takes the healed offset (which equals the nominal when nothing drifted, via the nominal
+ *          short-circuit); on a miss the slot keeps its current (nominal) value. A non-drift heal logs at
+ *          Debug; a recovered shift at Info; an unresolved REQUIRED landmark at Warning (it should have
+ *          been present, so a miss flags a layout the heal could not recover). An unresolved OPTIONAL
+ *          landmark (one that may legitimately not resolve in some game state) logs at Debug, since a miss
+ *          there is not necessarily drift.
+ * @return true when the landmark resolved (healed or confirmed at nominal), false on a miss.
+ */
+[[nodiscard]] bool heal_one(std::string_view label, const DMK::Rtti::Landmark &tmpl, std::uintptr_t base,
+                            std::atomic<std::ptrdiff_t> &slot, bool optional) noexcept
+{
+    DMK::Rtti::Landmark lm = tmpl;
+    lm.base = base;
+    lm.window = heal_window(); // override the per-struct default with the single tunable radius above
+    DMK::Logger &logger = DMK::Logger::get_instance();
+    const auto result = DMK::Rtti::heal_landmark(lm);
+    if (result)
+    {
+        slot.store(result->healed_offset, std::memory_order_relaxed);
+        if (result->healed_offset != tmpl.nominal_offset)
+        {
+            // Header first: emit the one drift Warning before the first moved line so it groups ABOVE the
+            // per-offset Info lines instead of interleaving (CAS one-shot, so later moves do not re-emit).
+            warn_layout_drift_once();
+            logger.info("Self-heal: {} moved {:+#x} ({:#x} -> {:#x})", label,
+                        result->healed_offset - tmpl.nominal_offset, tmpl.nominal_offset,
+                        result->healed_offset);
+        }
+        else
+        {
+            logger.debug("Self-heal: {} confirmed at nominal {:#x}", label, tmpl.nominal_offset);
+        }
+        return true;
+    }
+    const std::string_view reason = DMK::Rtti::heal_error_to_string(result.error());
+    if (optional)
+    {
+        logger.debug("Self-heal: {} not resolvable now ({}); keeping nominal {:#x}", label, reason,
+                     tmpl.nominal_offset);
+    }
+    else
+    {
+        logger.warning("Self-heal: {} unresolved ({}); kept nominal {:#x} (re-author if drifted)", label,
+                       reason, tmpl.nominal_offset);
+    }
+    return false;
+}
+
+} // namespace
+
+RuntimeOffsets &runtime_offsets() noexcept
+{
+    static RuntimeOffsets offsets;
+    return offsets;
+}
+
+void heal_player_offsets(std::uintptr_t c_player) noexcept
+{
+    // One-shot: the first call on a validated C_Player heals; later calls return immediately. The heals run
+    // on the render thread inside the already-SEH-guarded resolve path, so a single guard is sufficient.
+    static std::atomic<bool> s_done{false};
+    bool expected = false;
+    if (!s_done.compare_exchange_strong(expected, true, std::memory_order_relaxed))
+    {
+        return;
+    }
+
+    RuntimeOffsets &offsets = runtime_offsets();
+    // These members key on types that are UNIQUE within C_Player, so an independent window scan cannot land
+    // on a wrong same-typed neighbour; they heal independently, which keeps each one resilient to a shift
+    // that is not uniform across the struct. (entity is handled by the corroborated bracket below instead:
+    // CEntity is a common type, so an independent scan would be decoy-prone.) The missile controller is
+    // embedded in C_Player (constructed in its ctor), so its RTTI is normally resolvable at all times and it
+    // heals like the rest; it is passed optional only defensively, so any weapon/inventory state that left
+    // its slot unresolvable degrades to a Debug note rather than a spurious drift Warning.
+    (void)heal_one("animatedHuman", k_animhuman_lm, c_player, offsets.c_player_animated_human, false);
+    (void)heal_one("actorModel", k_actormodel_lm, c_player, offsets.c_player_actor_model, false);
+    (void)heal_one("missileController", k_missile_lm, c_player, offsets.c_player_missile_controller, true);
+
+    // animChar lives one hop out, on C_AnimatedHuman, so resolve that pointer through the (now healed)
+    // animated-human offset before healing it. A missing C_AnimatedHuman just leaves the nominal in place.
+    DMK::Logger &logger = DMK::Logger::get_instance();
+    const auto anim_human = DMK::Memory::seh_read<std::uintptr_t>(
+        c_player + offsets.c_player_animated_human.load(std::memory_order_relaxed));
+    if (anim_human && DMK::Memory::plausible_userspace_ptr(*anim_human))
+    {
+        (void)heal_one("animChar", k_animchar_lm, *anim_human, offsets.animated_human_animchar, false);
+    }
+    else
+    {
+        logger.debug("Self-heal: animChar skipped (C_AnimatedHuman not resolvable); keeping nominal {:#x}",
+                     Constants::ANIMATED_HUMAN_ANIMCHAR_OFFSET);
+    }
+
+    // Corroborated bracket: recover BOTH the entity pointer (common type, decoy-prone for a blind scan) and
+    // the look controller (no RTTI of its own) from the single top-of-struct delta that entity and
+    // HitDeathReactions both agree on (see k_player_top_bracket). Each rides the delta on success; a
+    // non-uniform shift fails the solve and both stay nominal (fail-closed).
+    const auto fit = DMK::Rtti::solve_fingerprint(c_player, k_player_top_bracket, heal_window());
+    if (fit)
+    {
+        const std::ptrdiff_t entity_healed = Constants::C_PLAYER_ENTITY_OFFSET + fit->delta;
+        const std::ptrdiff_t look_healed = Constants::C_PLAYER_LOOK_CONTROLLER_OFFSET + fit->delta;
+        offsets.c_player_entity.store(entity_healed, std::memory_order_relaxed);
+        offsets.c_player_look_controller.store(look_healed, std::memory_order_relaxed);
+        if (fit->delta != 0)
+        {
+            warn_layout_drift_once(); // header before the moved lines (see heal_one)
+            logger.info("Self-heal: entity moved {:+#x} ({:#x} -> {:#x})", fit->delta,
+                        Constants::C_PLAYER_ENTITY_OFFSET, entity_healed);
+            logger.info("Self-heal: lookController moved {:+#x} ({:#x} -> {:#x})", fit->delta,
+                        Constants::C_PLAYER_LOOK_CONTROLLER_OFFSET, look_healed);
+        }
+        else
+        {
+            logger.debug("Self-heal: entity + lookController confirmed at nominal (entity {:#x}, "
+                         "lookController {:#x})",
+                         Constants::C_PLAYER_ENTITY_OFFSET, Constants::C_PLAYER_LOOK_CONTROLLER_OFFSET);
+        }
+    }
+    else
+    {
+        // Bracket disagreed (non-uniform shift across the span). lookController has no RTTI of its own, so
+        // it cannot be recovered independently and stays nominal. entity CAN still be scanned for by type as
+        // a LAST RESORT: this reintroduces the decoy risk the corroborated solve avoided (a wrong same-typed
+        // CEntity neighbour could be picked), but a best-effort offset beats a guaranteed-stale one when the
+        // bracket has already failed, so try it and warn that the result is unverified.
+        logger.warning("Self-heal: bracket unresolved ({}); lookController kept nominal; entity via "
+                       "uncorroborated scan (decoy risk)",
+                       DMK::Rtti::heal_error_to_string(fit.error()));
+        (void)heal_one("entity (uncorroborated fallback)", k_entity_lm, c_player, offsets.c_player_entity,
+                       false);
+    }
+}
+
+std::ptrdiff_t heal_local_actor_offset(std::uintptr_t action_game) noexcept
+{
+    RuntimeOffsets &offsets = runtime_offsets();
+    (void)heal_one("localActor", k_localactor_lm, action_game, offsets.cactiongame_local_actor, false);
+    return offsets.cactiongame_local_actor.load(std::memory_order_relaxed);
+}
+
+void heal_context_offsets(std::uintptr_t context) noexcept
+{
+    // Each context member latches INDEPENDENTLY once its OWN heal resolves, so a rare frame where one member
+    // is not yet live retries only that member -- it never freezes the other at nominal (a single shared
+    // latch keyed on the manager would freeze the minigame member if it missed the latching frame) and never
+    // rescans a member that already healed. The context base is anchored, so unlike the local-actor offset a
+    // context-member drift IS recoverable here (the scan does not navigate through the offset it is healing).
+    // The caller gates this on the world being ready, when both subsystems are live.
+    static std::atomic<bool> s_manager_done{false};
+    static std::atomic<bool> s_minigame_done{false};
+    RuntimeOffsets &offsets = runtime_offsets();
+    if (!s_manager_done.load(std::memory_order_relaxed) &&
+        heal_one("cameraManager", k_manager_lm, context, offsets.context_manager, false))
+    {
+        s_manager_done.store(true, std::memory_order_relaxed);
+    }
+    if (!s_minigame_done.load(std::memory_order_relaxed) &&
+        heal_one("minigameSubsystem", k_minigame_subsystem_lm, context, offsets.context_minigame_subsystem,
+                 false))
+    {
+        s_minigame_done.store(true, std::memory_order_relaxed);
+    }
+}
+
+} // namespace TPVCamera

--- a/TPVCamera/src/offset_heal.hpp
+++ b/TPVCamera/src/offset_heal.hpp
@@ -1,0 +1,102 @@
+/**
+ * @file offset_heal.hpp
+ * @brief Self-healing offset cache for the player / context pointer chains.
+ *
+ * The pointer-chain navigation in camera_hook.cpp and game_state.cpp walks fixed field offsets inside
+ * structs whose base is resolved live (g_env / the anchored global context). A game patch that inserts or
+ * removes a struct member shifts every field after it, and a hardcoded offset then reads the wrong slot.
+ * This unit recovers the shifted offsets at runtime with DetourModKit's reverse-RTTI self-heal
+ * (rtti_dissect.hpp): each in-scope offset is keyed to the MSVC mangled name of the object its slot points
+ * at, and the heal scans a small window around the nominal offset for the slot that still resolves to that
+ * type. Only the offset is cached (a ptrdiff_t), never an absolute address, so the recovered value stays
+ * valid across instances and sessions.
+ *
+ * The cache holds the current nominal offsets until a heal runs, so behaviour is identical to a hardcoded
+ * build until a layout actually drifts. Healing is strictly fail-closed: an unrecoverable layout leaves the
+ * nominal offset in place (degrades to current behaviour, never a guessed offset, never a crash), exactly
+ * as DetourModKit's heal primitives guarantee. The heals are init-time / first-resolve only (the RTTI
+ * prelude is syscall-heavy), never per-frame; the per-frame chains just read one relaxed atomic each.
+ */
+#ifndef TPVCAMERA_OFFSET_HEAL_HPP
+#define TPVCAMERA_OFFSET_HEAL_HPP
+
+#include "constants.hpp"
+
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+
+namespace TPVCamera
+{
+
+/**
+ * @struct RuntimeOffsets
+ * @brief Live (possibly healed) copies of the in-scope pointer-chain field offsets.
+ * @details Each field is a lock-free atomic so the render thread can read it per frame while a one-shot
+ *          heal writes it once, with no torn read (a single aligned word) and no lock. Every field is
+ *          seeded with its constants.hpp nominal, so before any heal the cache reproduces the hardcoded
+ *          build exactly. Writes happen only inside the heal functions below (under a one-shot guard);
+ *          the chains read with relaxed ordering because the value is a standalone scalar with no
+ *          dependent data published through it, and a one-frame-stale nominal-vs-healed read is harmless
+ *          (both are valid offsets until the heal completes).
+ */
+struct RuntimeOffsets
+{
+    std::atomic<std::ptrdiff_t> cactiongame_local_actor{Constants::CACTIONGAME_LOCAL_ACTOR_OFFSET};
+    std::atomic<std::ptrdiff_t> c_player_entity{Constants::C_PLAYER_ENTITY_OFFSET};
+    std::atomic<std::ptrdiff_t> c_player_look_controller{Constants::C_PLAYER_LOOK_CONTROLLER_OFFSET};
+    std::atomic<std::ptrdiff_t> c_player_animated_human{Constants::C_PLAYER_ANIMATED_HUMAN_OFFSET};
+    std::atomic<std::ptrdiff_t> c_player_actor_model{Constants::C_PLAYER_ACTOR_MODEL_OFFSET};
+    std::atomic<std::ptrdiff_t> c_player_missile_controller{Constants::C_PLAYER_MISSILE_CONTROLLER_OFFSET};
+    std::atomic<std::ptrdiff_t> animated_human_animchar{Constants::ANIMATED_HUMAN_ANIMCHAR_OFFSET};
+    std::atomic<std::ptrdiff_t> context_manager{Constants::OFFSET_MANAGER_PTR_STORAGE};
+    std::atomic<std::ptrdiff_t> context_minigame_subsystem{Constants::OFFSET_MINIGAME_SUBSYSTEM};
+};
+
+/**
+ * @brief Returns the process-wide runtime offset cache.
+ * @details Backed by a single function-local static (no static-init-order dependency, like the other
+ *          shared state in global_state.hpp). Constructed on first use with every field at its nominal.
+ */
+[[nodiscard]] RuntimeOffsets &runtime_offsets() noexcept;
+
+/**
+ * @brief Heals the C_Player-rooted offsets once from a live, RTTI-validated C_Player.
+ * @details Independently heals the RTTI-typed members (entity, animated-human, actor-model, missile
+ *          controller) and the animated-character pointer one hop further out, then recovers the
+ *          look-controller offset (which has no RTTI of its own) from the tight bracket of its two
+ *          straddling RTTI neighbours. Each heal that resolves writes its cache field; each that cannot
+ *          leaves the nominal in place. One-shot: the first call on a validated C_Player does the work,
+ *          every later call returns immediately. Caller must pass a C_Player whose vtable already matched
+ *          C_PLAYER_RTTI_NAME (the members are only meaningful for a real C_Player). Render-thread only.
+ * @param c_player Live C_Player base address.
+ */
+void heal_player_offsets(std::uintptr_t c_player) noexcept;
+
+/**
+ * @brief Recovers the CActionGame local-actor offset when the cached slot no longer holds a C_Player.
+ * @details The look-up of C_Player itself navigates through this offset, so it cannot be healed from a
+ *          resolved C_Player (there is none until this offset is right). Instead the resolver calls this
+ *          when the cached slot holds a populated object that is NOT a C_Player (the signature of a
+ *          CActionGame layout drift): it scans a window around the nominal for the slot that resolves to
+ *          C_Player and caches it. The nominal slot is checked first, so an undrifted build resolves with
+ *          a single probe and no scan. Render-thread only.
+ * @param action_game Live CActionGame base address.
+ * @return The resulting local-actor offset (healed if recovered, else the unchanged cache value).
+ */
+[[nodiscard]] std::ptrdiff_t heal_local_actor_offset(std::uintptr_t action_game) noexcept;
+
+/**
+ * @brief Heals the global-context member offsets once (camera manager, minigame subsystem).
+ * @details Independently heals OFFSET_MANAGER_PTR_STORAGE and OFFSET_MINIGAME_SUBSYSTEM from the resolved
+ *          context object, keyed on the manager / minigame-subsystem RTTI names. Because the context base
+ *          is anchored (not navigated through a possibly-drifted offset), a top-of-context member
+ *          insertion is recoverable here. One-shot: the first call after the world is live does the work.
+ *          Render-thread only.
+ * @param context Resolved global-context object base address.
+ */
+void heal_context_offsets(std::uintptr_t context) noexcept;
+
+} // namespace TPVCamera
+
+#endif // TPVCAMERA_OFFSET_HEAL_HPP


### PR DESCRIPTION
## Summary

Adds a self-healing offset layer so the third-person camera survives a game patch that shifts struct layout. The mod's pointer-chain offsets (player, context, and action-game fields) are recovered at runtime from the RTTI type of the object each slot points at, using DetourModKit's reverse-RTTI self-heal, instead of shipping a re-reversed build for every update.

- Recovers the in-scope offsets once on first resolve; the per-frame chains then read a cached value, so there is no per-frame cost.
- Fail-closed: anything it cannot recover stays at the built-in offset, so behaviour is identical on the current build and it never crashes.
- Emits one Warning when a drift is detected (the non-healable scalar offsets still need a manual update), with each recovered offset logged at Info.
- Optional [Advanced] SelfHealWindow INI knob to widen the search if a future patch moves a field far.

No user-facing behaviour change on the current game build. Verified live: offsets recover correctly under simulated drift in both directions, and fail closed otherwise.
