### PR TITLE
chore(tpvcamera): bump DetourModKit to v3.8.2

### DIFF
--- a/TPVCamera/CMakeLists.txt
+++ b/TPVCamera/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.25)
+cmake_minimum_required(VERSION 3.28)
 
 # Derive the project version from src/version.hpp, the single source of truth
 # (scripts/version_updater.py bumps only that header). PROJECT_VERSION currently feeds only the

--- a/TPVCamera/CMakePresets.json
+++ b/TPVCamera/CMakePresets.json
@@ -2,7 +2,7 @@
   "version": 6,
   "cmakeMinimumRequired": {
     "major": 3,
-    "minor": 25,
+    "minor": 28,
     "patch": 0
   },
   "configurePresets": [

--- a/TPVCamera/docs/NEXT_CHANGELOG.md
+++ b/TPVCamera/docs/NEXT_CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [Title for next release]
 
-- Updated the bundled modding toolkit (DetourModKit) to the latest version (v3.8.0)
+- Updated the bundled modding toolkit (DetourModKit) to the latest version (v3.8.2)
 - Fixed the preset overlay looking blurry or misaligned on displays scaled above 100%
 - Saved camera presets can no longer be lost if the game closes while they are being written
 - The third-person camera now automatically adapts to many game updates that move data around internally, so a common patch no longer breaks it before the mod is updated

--- a/TPVCamera/src/offset_heal.cpp
+++ b/TPVCamera/src/offset_heal.cpp
@@ -52,8 +52,8 @@ constexpr std::size_t k_heal_window_default = 0x100;
 // this mangled type." Each is keyed on a type that is stable across patches (an engine/base type or an
 // already-trusted concrete type), per the rtti_dissect guidance. base is filled at call time. The
 // indirection records the slot SHAPE: every member here is a pointer-to-object EXCEPT the missile
-// controller, which is constructed in-place inside C_Player (its first qword is the vtable), so its slot is
-// a direct object base.
+// controller, which is constructed in-place inside C_Player (its first qword is the vtable), so it is a
+// direct object base matched with CompleteObject (see k_missile_lm for why CompleteObject, not ObjectBase).
 constexpr DMK::Rtti::Landmark k_entity_lm{
     .nominal_offset = Constants::C_PLAYER_ENTITY_OFFSET,
     .expected_mangled = Constants::C_ENTITY_RTTI_NAME,
@@ -69,7 +69,13 @@ constexpr DMK::Rtti::Landmark k_actormodel_lm{
 constexpr DMK::Rtti::Landmark k_missile_lm{
     .nominal_offset = Constants::C_PLAYER_MISSILE_CONTROLLER_OFFSET,
     .expected_mangled = Constants::C_MISSILE_CONTROLLER_RTTI_NAME,
-    .indirection = DMK::Rtti::Indirection::ObjectBase}; // embedded object, not a pointer
+    // Embedded object, not a pointer. CompleteObject matches only the primary subobject (COL.offset == 0),
+    // where ObjectBase would match any subobject: under multiple inheritance every base carries its own
+    // vtable and each vtable's COL names the same most-derived type, so a window scan keyed on ObjectBase
+    // could latch a secondary base and heal to an offset shifted by that subobject delta (a silent,
+    // confidence-full off-by-a-subobject heal). The embedded member's nominal slot already holds the primary
+    // vtable, so CompleteObject only adds the MI guard for the drift scan and never changes the nominal match.
+    .indirection = DMK::Rtti::Indirection::CompleteObject};
 constexpr DMK::Rtti::Landmark k_animchar_lm{
     .nominal_offset = Constants::ANIMATED_HUMAN_ANIMCHAR_OFFSET,
     .expected_mangled = Constants::ANIMATED_CHARACTER_RTTI_NAME,


### PR DESCRIPTION
## Summary

Updates TPVCamera's bundled DetourModKit from v3.8.0 to v3.8.2.

The release adds Indirection::CompleteObject for multiple-inheritance-safe self-heal. The embedded missile-controller landmark now uses it instead of ObjectBase so a drifted layout cannot latch a secondary base and recover an offset shifted by the subobject delta. Behaviour is unchanged on an undrifted build.

Also raises the project CMake minimum to 3.28 to match the dependency, and refreshes the vendored deps that ship with v3.8.2.

