### PR TITLE
feat(tpvcamera): stable aim basis + patch-resilience hardening

### DIFF
--- a/TPVCamera/README.md
+++ b/TPVCamera/README.md
@@ -105,7 +105,7 @@ so those contexts render from the untouched engine view.
 Edit `KCD2_TPVCamera.ini`. It is grouped into:
 
 - `[Settings]` - log level, the view hotkeys (`ToggleViewKey`, `ForceFPVKey`, `ForceTPVKey`), the preset-overlay key (`ToggleOverlayKey`), and the start-of-session auto-enable flags
-- `[Camera]` - zoom keys, the camera-space interaction toggle, and the view-transition ease (the framing itself is per-preset; see `[Presets]`)
+- `[Camera]` - zoom keys, the camera-space interaction toggle, the view-transition ease, and the camera-stability options (`StableAimBasis`, `AimBasisSmoothing`) that keep the view steady against head-bob, sway, and combat shake (the framing itself is per-preset; see `[Presets]`)
 - `[Orbit]` - the free-look orbit keys (press-to-toggle and momentary hold) and the cursor freeze (the orbit feel is per-preset)
 - `[Collision]` - the collision probe and radius, `UseCoverageCollision` (only pull in for things that hide your character) with its coverage / side-wall options, and the independent `UseRenderOcclusion` cloth-roof clamp (enable, skin, and return speed are per-preset)
 - `[StateBehavior]` - switch first/third person on entering a situation (combat, aiming, dialogue, minigame, mount, menu, overlay), restore the prior view on exit (manual toggles during it stick), and suspend/restore free-look in chosen situations

--- a/TPVCamera/build/template/KCD2_TPVCamera.ini
+++ b/TPVCamera/build/template/KCD2_TPVCamera.ini
@@ -75,6 +75,20 @@ InteractFromCamera = true
 ; of snapping. 0 = instant. Live-editable. Default: 0.0
 ViewTransitionDuration = 0.0
 
+; StableAimBasis keeps the third-person camera steady against the shake the game adds to the first-person view.
+; Walking head-bob, weapon sway, combat, hits and landings all jitter the rendered view; because the camera sits
+; FollowDistance behind you, that jitter is magnified into a swinging camera. With this on, the camera is built from
+; your actual look/aim direction instead of the shaken view, so it stays steady while still following where you look.
+; (A few scripted animations such as climbing briefly move your look itself, so a small shift can remain there.)
+; Turn it off to use the raw engine view (shake included). Global toggle (not per-preset). Live-editable. Default: true
+StableAimBasis = true
+
+; AimBasisSmoothing low-passes the camera orientation to damp any residual rotation, 0..1. It applies whether or
+; not StableAimBasis is on (with StableAimBasis off it smooths the raw engine view instead of your aim direction).
+; 0 = off (no smoothing); higher = smoother but slightly laggier when you turn the camera quickly. 0.3 is a gentle
+; default that removes the last of the jitter without a noticeable lag. Live-editable. Default: 0.3
+AimBasisSmoothing = 0.3
+
 ; ===== FREE-LOOK ORBIT =====
 [Orbit]
 ; NOTE: the orbit FEEL -- sensitivity, pitch limits, return speed, smoothing, level-aim, body-turn, continuous-align --
@@ -161,7 +175,7 @@ CollisionRadius = 0.15
 ;     Crouch     crouching / sneaking ("Stealth" is an accepted alias)
 ;     Lying      lying down (sleeping in a bed)
 ;     Sitting    sitting on a bench or chair
-;     Kneel      kneeling (e.g. praying)
+;     Kneel      kneeling
 ;     Cart       riding or driving a cart
 ;
 ;   Minigame:

--- a/TPVCamera/docs/NEXT_CHANGELOG.md
+++ b/TPVCamera/docs/NEXT_CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [Title for next release]
 
-- New feature
-- Bug fix
-- Improvement
+- Fixed the third-person camera shaking or drifting while the game plays an animation such as opening a door, looting, or fighting
+- Added two options to keep the view steady (Stable Aim Basis and Aim Basis Smoothing), both on by default and adjustable in the INI
+- Strengthened the camera's ability to keep working after game updates

--- a/TPVCamera/docs/nexus-bbcode.txt
+++ b/TPVCamera/docs/nexus-bbcode.txt
@@ -95,7 +95,7 @@ On a controller the zoom shares the D-pad with the game's inventory/map shortcut
 Edit KCD2_TPVCamera.ini, grouped into:
 [list]
 [*][b][Settings][/b] - log level, the view hotkeys, the preset-overlay key, and the start-of-session auto-enable flags[/*]
-[*][b][Camera][/b] - zoom keys, the camera-space interaction toggle, and the view-transition ease (the framing itself is per-preset)[/*]
+[*][b][Camera][/b] - zoom keys, the camera-space interaction toggle, the view-transition ease, and the camera-stability options (StableAimBasis, AimBasisSmoothing) that keep the view steady against head-bob, sway, and combat shake (the framing itself is per-preset)[/*]
 [*][b][Orbit][/b] - the free-look orbit keys (press-to-toggle and momentary hold) and the cursor freeze (the orbit feel is per-preset)[/*]
 [*][b][Collision][/b] - the collision probe and radius, UseCoverageCollision (only pull in for things that hide your character) with its coverage / side-wall options, and the independent UseRenderOcclusion cloth-roof clamp (enable, skin, and return speed are per-preset)[/*]
 [*][b][StateBehavior][/b] - switch first/third person on entering a situation (combat, aiming, dialogue, minigame, mount, menu, overlay), restore the prior view on exit (manual toggles during it stick), and suspend/restore free-look in chosen situations[/*]

--- a/TPVCamera/src/aob_resolver.hpp
+++ b/TPVCamera/src/aob_resolver.hpp
@@ -59,21 +59,23 @@ namespace TPVCamera
     namespace Aob
     {
         // --- Global-context storage slot (qword_18549B4B0) -------------------
-        // RipRelative: all three candidates resolve the SAME data slot the
-        // camera-manager walk reads (context + OFFSET_MANAGER_PTR_STORAGE). P1
-        // anchors in the TLS-guarded accessor (sub_18091C138) on the `jg` that
-        // skips the fast-path epilogue; the mov it precedes loads the slot. The
-        // accessor's body is a generic magic-static guard shared by dozens of
-        // sibling accessors, so P2/P3 instead anchor on two OTHER functions that
-        // load the slot, each isolated by a distinctive neighbouring field test
-        // (cmp qword [rax+0E0h] / mov [rax+0F8h]). Three independent code sites
-        // means a patch must move all three before the slot is lost.
+        // RipRelative: all three candidates resolve the SAME data slot the camera-manager walk reads (context +
+        // OFFSET_MANAGER_PTR_STORAGE), across three different functions that load it. None anchors on a short Jcc
+        // (rel8 opcodes 70-7F/EB/E3 flip to rel32 across builds and desync the pattern); each pins instead on a
+        // distinctive NON-Jcc neighbour of the slot-load `mov rax,[rip+slot]` (48 8B 05, disp32 -> the slot):
+        // P1 (sub_180682A08) leads with `mov eax,[rbx+r14]; cmp cs:dword,eax; jg-far` (the SIB 0x33 base/index
+        // pins this site over a near-twin that shares the field test) and ends on the `cmp qword [rax+0E0h]`
+        // field; P2 (sub_180B284B8) leads with `cmp cs:dword,ebx` and ends on `mov rbp,[rax+0F8h]`; P3
+        // (sub_180F1B788) is pinned by the `mov rcx,[rdi+278h]` neighbour and `mov rsi,[rax+0F8h]`. Three
+        // independent code sites mean a patch must move all three before the slot is lost. All resolve to
+        // 0x18549B4B0.
         inline constexpr AddrCandidate k_contextCandidates[] = {
-            {"Context_P1_GuardJgFastPathMov", "7F ?? 48 8B 05 ?? ?? ?? ?? 48 83 C4 ?? 5B C3", ResolveMode::RipRelative,
-             5, 9},
-            {"Context_P2_LoadCheckFieldE0", "48 8B 05 ?? ?? ?? ?? 48 83 B8 E0 00 00 00 00 74 ?? 42 8B 04 33 39 05",
-             ResolveMode::RipRelative, 3, 7},
-            {"Context_P3_LoadFieldF8Jnz", "48 8B 05 ?? ?? ?? ?? 48 8B A8 F8 00 00 00 75 ?? E8",
+            {"Context_P1_ReadSlotCmpFieldE0",
+             "42 8B 04 33 39 05 ?? ?? ?? ?? 0F 8F ?? ?? ?? ?? 48 8B 05 ?? ?? ?? ?? 48 83 B8 E0 00 00 00 00",
+             ResolveMode::RipRelative, 19, 23},
+            {"Context_P2_ReadSlotFieldF8", "39 1D ?? ?? ?? ?? 48 8B 05 ?? ?? ?? ?? 48 8B A8 F8 00 00 00",
+             ResolveMode::RipRelative, 9, 13},
+            {"Context_P3_ReadSlotField278", "48 8B 05 ?? ?? ?? ?? 48 8B 8F 78 02 00 00 48 8B B0 F8 00 00 00",
              ResolveMode::RipRelative, 3, 7},
         };
 
@@ -132,22 +134,22 @@ namespace TPVCamera
              ResolveMode::Direct, -0x0A, 0},
         };
 
-        // --- Generic input-event dispatcher entry ---------------------------
-        // Direct entry hook. The `cmp [rcx+0D8h], r8b` guard is the unique
-        // landmark; the jnz rel8 that skips it is wildcarded. P2 extends past the
-        // first jz rel32 into the `cmp [rdx+10h], -1` pitch check. P3 drops the
-        // two prologue stores and walks back 0x0A.
+        // --- Generic input-event dispatcher entry (0x180862BD8) -------------
+        // Direct entry hook, located by walking back from a mid-body landmark to the entry. The function is
+        // reached only virtually (no call site) and its prologue is a generic shape that is not unique on its
+        // own, so all three anchors are distinctive body runs PAST the prologue -- which also means a sibling
+        // 5-byte prologue hook does not break them. None anchors on a short Jcc: the volatile `jnz rel8` guard is
+        // never inside the pattern, and the far `jz rel32` branches that ARE included have their rel32 wildcarded.
+        // P1 = `cmp [rcx+0D8h],r8b; jz-far; cmp [rdx+10h],-1; jz-far` (entry+0x15); P2 = that pitch check into
+        // `mov rax,[rip]; mov ecx,[rax]; test ecx,ecx` (entry+0x22); P3 = the eIS_Changed block
+        // `movzx; movss; mov rcx,[rip]; mov r8,[rbx+8]; cvtps2pd` (entry+0x50). Each walks back to the entry.
         inline constexpr AddrCandidate k_inputDispatchCandidates[] = {
-            {"Input_P1_PrologueGuardCmp",
-             "48 89 5C 24 08 57 48 83 EC ?? 48 8B DA 48 8B F9 45 84 C0 75 ?? 44 38 81 D8 00 00 00 0F 84",
-             ResolveMode::Direct, 0, 0},
-            {"Input_P2_GuardThroughPitchCmp",
-             "48 89 5C 24 08 57 48 83 EC ?? 48 8B DA 48 8B F9 45 84 C0 75 ?? 44 38 81 D8 00 00 00 0F 84 "
-             "?? ?? ?? ?? 83 7A 10 FF 0F 84",
-             ResolveMode::Direct, 0, 0},
-            {"Input_P3_BodyGuardCmpPitch",
-             "48 8B DA 48 8B F9 45 84 C0 75 ?? 44 38 81 D8 00 00 00 0F 84 ?? ?? ?? ?? 83 7A 10 FF", ResolveMode::Direct,
-             -0x0A, 0},
+            {"Input_P1_BodyFlagCmpFarJz",
+             "44 38 81 D8 00 00 00 0F 84 ?? ?? ?? ?? 83 7A 10 FF 0F 84 ?? ?? ?? ??", ResolveMode::Direct, -0x15, 0},
+            {"Input_P2_PitchCmpRipMov", "83 7A 10 FF 0F 84 ?? ?? ?? ?? 48 8B 05 ?? ?? ?? ?? 8B 08 85 C9",
+             ResolveMode::Direct, -0x22, 0},
+            {"Input_P3_ChangedLogBlock", "0F B6 52 28 F3 0F 10 5B 18 48 8B 0D ?? ?? ?? ?? 4C 8B 43 08 0F 5A DB",
+             ResolveMode::Direct, -0x50, 0},
         };
 
         // --- Global action dispatcher entry (Lua Player:OnAction source) -----

--- a/TPVCamera/src/config.cpp
+++ b/TPVCamera/src/config.cpp
@@ -64,6 +64,12 @@ namespace TPVCamera
                                            s.interact_from_camera, true);
         DMK::Config::register_atomic<float>("Camera", "ViewTransitionDuration", "View Transition Duration",
                                             s.view_transition_duration, 0.0f);
+        // Camera stability against engine view-shake amplified by the follow distance (see LiveSettings).
+        // StableAimBasis builds the rig basis from the clean look-controller aim quat; AimBasisSmoothing
+        // low-passes the basis (0 = off). Both always-live.
+        DMK::Config::register_atomic<bool>("Camera", "StableAimBasis", "Stable Aim Basis", s.stable_aim_basis, true);
+        DMK::Config::register_atomic<float>("Camera", "AimBasisSmoothing", "Aim Basis Smoothing",
+                                            s.aim_basis_smoothing, 0.3f);
 
         // Free-look orbit (non-preset, always-live; the orbit feel values are per-preset).
         DMK::Config::register_atomic<bool>("Orbit", "FreezeOrbitOnCursor", "Freeze Orbit On Cursor",

--- a/TPVCamera/src/config.hpp
+++ b/TPVCamera/src/config.hpp
@@ -172,6 +172,19 @@ namespace TPVCamera
         // suppression slide instead of snapping; 0 = instant switch.
         std::atomic<float> view_transition_duration{0.0f};
 
+        // Camera stability (always-live, NOT preset-owned). The third-person rig (camera = pivot - forward *
+        // distance) amplifies any rotation of the basis into a position swing; the EyeHeight body anchor removes
+        // the POSITIONAL bob, these remove the ROTATIONAL component the engine bakes into the eye quat during
+        // animations (head-bob and weapon-sway rotation, combat / hit / landing view-shake). StableAimBasis
+        // builds the rig basis from the player's clean look-controller aim quat instead of that shaking eye quat
+        // (the look carries none of it and equals the eye at rest), falling back to the eye quat if the look
+        // chain cannot be resolved. AimBasisSmoothing then low-passes the result (0 = off; higher = smoother but
+        // slightly laggier aim). Both default ON. (The look briefly diverges from the rendered view during some
+        // scripted animations such as climbing, so a small residual shift can remain there; this is preferred
+        // over the much larger general view-shake that follow-the-eye would otherwise reintroduce.)
+        std::atomic<bool> stable_aim_basis{true};
+        std::atomic<float> aim_basis_smoothing{0.3f};
+
         // Start-of-session auto-enable flags, read ONCE during init(). Disabled by default.
         std::atomic<bool> auto_enable_tpv{false};   // enter third-person automatically on game start
         std::atomic<bool> auto_enable_orbit{false}; // engage free-look orbit automatically on game start

--- a/TPVCamera/src/constants.hpp
+++ b/TPVCamera/src/constants.hpp
@@ -95,6 +95,8 @@ namespace Constants
     constexpr ptrdiff_t GENV_PGAME_OFFSET = 0x90;
     constexpr ptrdiff_t IGAME_GET_FRAMEWORK_VTABLE_OFFSET = 0x80; // IGame vtable slot 16
     constexpr ptrdiff_t CCRYACTION_ACTIONGAME_OFFSET = 0x88;
+    // RTTI type-descriptor name of CActionGame, the self-heal anchor for CCRYACTION_ACTIONGAME_OFFSET.
+    constexpr const char *CACTIONGAME_RTTI_NAME = ".?AVCActionGame@@";
     constexpr ptrdiff_t CACTIONGAME_LOCAL_ACTOR_OFFSET = 0xA40;
     constexpr ptrdiff_t C_PLAYER_LOOK_CONTROLLER_OFFSET = 0x238;
     // The look-controller pointee is a non-polymorphic struct with no RTTI, so the self-heal layer cannot
@@ -112,6 +114,14 @@ namespace Constants
     // driven separately via the BODY-turn constants below.
     constexpr ptrdiff_t LOOK_CONTROLLER_YAW_OFFSET = 0x10;
     constexpr ptrdiff_t LOOK_CONTROLLER_YAW2_OFFSET = 0x44;
+    // The derived look quaternion (XYZW) the cameras read, at controller + 0x24. It is the player's clean AIM
+    // orientation: re-derived from the scalar pitch+yaw every frame, so it carries NO head-bob, weapon-sway, or
+    // engine view-shake (combat / hit / landing). At rest it equals the CView eye quat (SVIEWPARAMS_ROTATION_
+    // OFFSET) exactly; during an action the eye quat diverges by the view-shake while this stays on the aim.
+    // StableAimBasis builds the third-person rig basis from THIS instead of the bobbing/shaking eye quat, so a
+    // multi-meter follow distance no longer amplifies the eye-quat view-shake into a camera-position swing.
+    // Live-verified on retail 1.5.5.
+    constexpr ptrdiff_t LOOK_CONTROLLER_QUAT_OFFSET = 0x24;
 
     // --- Player BODY-turn: force the entity world yaw (camera-relative body facing) ----------------
     // The look controller above is aim-only, so a separate primitive turns the BODY. The engine's
@@ -137,6 +147,13 @@ namespace Constants
     constexpr const char *ANIMATED_CHARACTER_RTTI_NAME = ".?AVCAnimatedCharacter@@";
     constexpr ptrdiff_t ANIMCHAR_OVERRIDE_ROT_ACTIVE_OFFSET = 0x1D8; // BYTE, set to 1 each frame (consume-once)
     constexpr ptrdiff_t ANIMCHAR_OVERRIDE_ROT_QUAT_OFFSET = 0x1DC;   // world Quat XYZW (16 bytes)
+    // Component offsets within a 16-byte quaternion (4 contiguous floats, X Y Z W). Used to write the
+    // override-rotation quat above field by field; a quat is always this packed-float layout, so these are
+    // sizeof(float) strides, not an engine-version struct map.
+    constexpr ptrdiff_t QUAT_X_OFFSET = 0x0;
+    constexpr ptrdiff_t QUAT_Y_OFFSET = 0x4;
+    constexpr ptrdiff_t QUAT_Z_OFFSET = 0x8;
+    constexpr ptrdiff_t QUAT_W_OFFSET = 0xC;
 
     // The head-visibility setter (k_headVisibilityCandidates) has signature
     // void __fastcall(this /*rcx*/, bool hide_head /*dl*/, char flags /*r8b*/). The
@@ -281,6 +298,9 @@ namespace Constants
     // primitives::sphere { Vec3 center; float r; } -- 16 bytes, type id 4. center is WORLD space.
     constexpr int PRIMITIVE_TYPE_SPHERE = 4;
     constexpr size_t PRIMITIVE_SPHERE_SIZE = 0x10;
+    // primitives::sphere is { Vec3 center; float r; }: center at +0, radius float at +0xC (a fixed POD layout,
+    // not an engine-version struct map).
+    constexpr ptrdiff_t PRIMITIVE_SPHERE_RADIUS_OFFSET = 0xC;
 
     // Fork SPWIParams field offsets, reversed from the impl (sub_1808182A0) reading its 2nd arg and
     // the constructing caller (sub_180817E4C). The struct is heavily reorganized vs the generic
@@ -306,6 +326,14 @@ namespace Constants
     constexpr ptrdiff_t SPWI_OFF_LOCK_IACTIVE = 0xD8; // int  WriteLockCond.iActive (CONFIRMED)
     constexpr ptrdiff_t SPWI_OFF_LOCK_PRW =
         0xE0; // int* WriteLockCond.prw     (CONFIRMED; self-ptr = thread-safe, no global lock)
+
+    // SPWI field VALUES (written INTO the fields above; the offsets are the field positions, these are the
+    // contents). Kept named alongside the offsets so a tuning change is one edit, not a hunt through the impl.
+    // Flags value for SPWI_OFF_FLAGS: the impl tests &0x800 (rwi_queue); 0x101 is the full-range value that
+    // registers both close and far contacts. Must NOT include 0x800 (that would queue, not run synchronous).
+    constexpr int SPWI_FLAGS_FULL_RANGE = 0x101;
+    // Colltype mask for SPWI_OFF_GEOMFLAGSANY: stop the sphere on ANY solid surface (mirrors the RWI intent).
+    constexpr int SPWI_GEOMFLAGS_ANY_SOLID = 0x0FFF;
 
     // --- Render-node camera occlusion (collide with render-only roofs RWI/PWI cannot see) ---
     // Some KCD2 roofs (tent / awning canopy cloth, e.g. canopy_tent_cover_a_nosticks.cgf) are CBrush

--- a/TPVCamera/src/global_state.hpp
+++ b/TPVCamera/src/global_state.hpp
@@ -175,6 +175,18 @@ namespace TPVCamera
         float fov_ease_stage1{0.0f};
         float fov_ease_applied{0.0f};
         bool fov_ease_valid{false};
+
+        // Aim-basis low-pass (render thread only). The third-person rig basis quaternion (XYZW), low-passed
+        // toward the per-frame target (the look-controller aim quat under StableAimBasis, else the eye quat)
+        // when AimBasisSmoothing is on, so engine-driven view rotation -- which the follow distance amplifies
+        // into a camera-position swing -- is damped. basis_quat_valid is cleared on suppression (and is false
+        // on first engage) so the next engaged frame SNAPS to the current orientation instead of slerping
+        // across the first-person gap, matching the orbit / eye-sync / FOV / collision smoothers.
+        float basis_quat_x{0.0f};
+        float basis_quat_y{0.0f};
+        float basis_quat_z{0.0f};
+        float basis_quat_w{1.0f};
+        bool basis_quat_valid{false};
     };
 
     /**

--- a/TPVCamera/src/hooks/camera_hook.cpp
+++ b/TPVCamera/src/hooks/camera_hook.cpp
@@ -231,6 +231,13 @@ namespace TPVCamera
     constexpr float k_orbit_smooth_min_speed = 6.0f;  // strength 1.0: heavy smoothing
     constexpr float k_orbit_smooth_max_speed = 40.0f; // strength near 0: barely-there smoothing
 
+    // Aim-basis low-pass (AimBasisSmoothing). Maps the 0..1 strength to a frame-rate-independent slerp
+    // catch-up speed: higher strength -> lower speed -> more damping (and slightly laggier aim). The window
+    // is faster than the orbit low-pass so even at full strength the camera still tracks genuine aim turns
+    // closely while shedding the high-frequency view-shake.
+    constexpr float k_basis_smooth_min_speed = 8.0f;  // strength 1.0: heaviest damping
+    constexpr float k_basis_smooth_max_speed = 60.0f; // strength near 0: barely-there damping
+
     // Maximum aim-convergence toe-in. The off-axis camera toes in toward the aim focus point by
     // atan(|OffsetRight| / (focus_distance + follow_distance)); that angle is ALSO the residual crosshair
     // error for any target past the focus. Bounding it stops a small follow distance combined with a
@@ -340,8 +347,13 @@ namespace TPVCamera
             }
         }
 
-        const auto p_action_game =
-            DMK::Memory::seh_read<uintptr_t>(s_cry_action + Constants::CCRYACTION_ACTIONGAME_OFFSET);
+        // Heal the CCryAction -> CActionGame offset once (keyed on CActionGame RTTI) before reading through it:
+        // it is the root of the actor chain, so a layout shift here would silently break every walk below.
+        // Latches on success, so it is nominal until CActionGame is constructed, then fixed.
+        heal_framework_offset(s_cry_action);
+
+        const auto p_action_game = DMK::Memory::seh_read<uintptr_t>(
+            s_cry_action + runtime_offsets().ccryaction_actiongame.load(std::memory_order_relaxed));
         if (!p_action_game || !DMK::Memory::plausible_userspace_ptr(*p_action_game))
         {
             return 0;
@@ -476,8 +488,11 @@ namespace TPVCamera
             }
         }
 
-        const auto p_action_game =
-            DMK::Memory::seh_read<uintptr_t>(s_cry_action + Constants::CCRYACTION_ACTIONGAME_OFFSET);
+        // Heal the chain-root CCryAction -> CActionGame offset once (one-shot internally), as the resolver does.
+        heal_framework_offset(s_cry_action);
+
+        const auto p_action_game = DMK::Memory::seh_read<uintptr_t>(
+            s_cry_action + runtime_offsets().ccryaction_actiongame.load(std::memory_order_relaxed));
         if (!p_action_game || !DMK::Memory::plausible_userspace_ptr(*p_action_game))
         {
             return;
@@ -595,10 +610,10 @@ namespace TPVCamera
         // Yaw-only world quat (XYZW): rotation about +Z by target_yaw == {0, 0, sin(y/2), cos(y/2)}.
         const float half = target_yaw * 0.5f;
         const uintptr_t quat_addr = *anim_char + Constants::ANIMCHAR_OVERRIDE_ROT_QUAT_OFFSET;
-        *reinterpret_cast<float *>(quat_addr + 0x0) = 0.0f;
-        *reinterpret_cast<float *>(quat_addr + 0x4) = 0.0f;
-        *reinterpret_cast<float *>(quat_addr + 0x8) = std::sin(half);
-        *reinterpret_cast<float *>(quat_addr + 0xC) = std::cos(half);
+        *reinterpret_cast<float *>(quat_addr + Constants::QUAT_X_OFFSET) = 0.0f;
+        *reinterpret_cast<float *>(quat_addr + Constants::QUAT_Y_OFFSET) = 0.0f;
+        *reinterpret_cast<float *>(quat_addr + Constants::QUAT_Z_OFFSET) = std::sin(half);
+        *reinterpret_cast<float *>(quat_addr + Constants::QUAT_W_OFFSET) = std::cos(half);
         // Set the active byte LAST so the animated-character update (a separate consumer) never reads
         // active==1 with a half-written quat. The release fence orders the quat stores before the active
         // store explicitly rather than relying on the target's store-store ordering; on x86 it lowers to a
@@ -682,9 +697,91 @@ namespace TPVCamera
         }
         const Vector3 eye_position = *eye_position_read;
         const Quaternion eye_rotation = *eye_rotation_read;
-        const Vector3 right = eye_rotation.rotate(Vector3{1.0f, 0.0f, 0.0f});
-        const Vector3 forward = eye_rotation.rotate(Vector3{0.0f, 1.0f, 0.0f});
-        const Vector3 up = eye_rotation.rotate(Vector3{0.0f, 0.0f, 1.0f});
+        // FPV-side basis (the engine eye orientation). Kept as the view-blend SOURCE so view_blend 0 leaves
+        // the untouched first-person view; the third-person rig basis below is built from a STABLE source.
+        const Vector3 eye_forward = eye_rotation.rotate(Vector3{0.0f, 1.0f, 0.0f});
+        const Vector3 eye_up = eye_rotation.rotate(Vector3{0.0f, 0.0f, 1.0f});
+
+        // Stable rig basis. The third-person rig (camera = pivot - forward * distance) amplifies any rotation of
+        // the basis into a position swing; the EyeHeight body anchor removed the POSITIONAL bob, this removes the
+        // ROTATIONAL component the engine bakes into the eye quat during animations (head-bob and weapon-sway
+        // rotation, combat / hit / landing shake). StableAimBasis follows the player's clean look-controller AIM
+        // quat instead -- it carries none of that engine view-shake and equals the eye quat at rest -- and
+        // AimBasisSmoothing low-passes it. basis_overridden records whether the basis was shaped at all: when
+        // neither feature is active it stays the raw eye quat and the orientation path below is byte-identical to
+        // the convergence/orbit-only behaviour (a fail-safe default).
+        Quaternion basis_rotation = eye_rotation;
+        bool basis_overridden = false;
+        Quaternion look_rotation = eye_rotation;
+        bool look_valid = false;
+        if (cfg.stable_aim_basis.load(std::memory_order_relaxed) && c_player != 0)
+        {
+            // Read the look controller through the self-healed offset (seeded from the constant, recovered if
+            // the C_Player layout drifts) so the basis tracks the same controller the orbit aim control writes.
+            const auto controller = DMK::Memory::seh_read<uintptr_t>(
+                c_player + runtime_offsets().c_player_look_controller.load(std::memory_order_relaxed));
+            if (controller && DMK::Memory::plausible_userspace_ptr(*controller))
+            {
+                const auto look_quat =
+                    DMK::Memory::seh_read<Quaternion>(*controller + Constants::LOOK_CONTROLLER_QUAT_OFFSET);
+                if (look_quat)
+                {
+                    const Quaternion q = *look_quat;
+                    const float n2 = q.x * q.x + q.y * q.y + q.z * q.z + q.w * q.w;
+                    // Accept only a finite, ~unit quaternion: a layout drift feeding garbage must fall back to
+                    // the eye quat, never rotate the rig by a denormal.
+                    if (std::isfinite(n2) && n2 > 0.9f && n2 < 1.1f)
+                    {
+                        look_rotation = q;
+                        look_valid = true;
+                    }
+                }
+            }
+        }
+        // Low-pass the basis quaternion toward the target -- the look quat when StableAimBasis resolved it, else
+        // the raw eye quat. Snaps on the first engaged frame (basis_quat_valid false) so the camera does not
+        // swing in from a stale orientation across a first-person gap. AimBasisSmoothing 0 disables the filter
+        // (the target is used directly).
+        const float basis_smoothing = std::clamp(cfg.aim_basis_smoothing.load(std::memory_order_relaxed), 0.0f, 1.0f);
+        if (look_valid || basis_smoothing > 1e-4f)
+        {
+            basis_overridden = true;
+            const DirectX::XMVECTOR target = (look_valid ? look_rotation : eye_rotation).to_xm_vector();
+            DirectX::XMVECTOR result;
+            if (!cam.basis_quat_valid)
+            {
+                result = target; // snap on the first engaged frame so the camera does not swing in from stale
+                cam.basis_quat_valid = true;
+            }
+            else if (basis_smoothing > 1e-4f)
+            {
+                const DirectX::XMVECTOR current =
+                    DirectX::XMVectorSet(cam.basis_quat_x, cam.basis_quat_y, cam.basis_quat_z, cam.basis_quat_w);
+                const float speed =
+                    k_basis_smooth_max_speed - basis_smoothing * (k_basis_smooth_max_speed - k_basis_smooth_min_speed);
+                const float t = 1.0f - std::exp(-speed * delta_time);
+                // XMQuaternionSlerp takes the shortest arc, so a quaternion double-cover sign flip never spins the
+                // basis the long way.
+                result = DirectX::XMQuaternionNormalize(DirectX::XMQuaternionSlerp(current, target, t));
+            }
+            else
+            {
+                result = target; // StableAimBasis on, smoothing off: use the look target directly
+            }
+            cam.basis_quat_x = DirectX::XMVectorGetX(result);
+            cam.basis_quat_y = DirectX::XMVectorGetY(result);
+            cam.basis_quat_z = DirectX::XMVectorGetZ(result);
+            cam.basis_quat_w = DirectX::XMVectorGetW(result);
+            basis_rotation = Quaternion{cam.basis_quat_x, cam.basis_quat_y, cam.basis_quat_z, cam.basis_quat_w};
+        }
+        else
+        {
+            cam.basis_quat_valid = false; // basis not shaped: the next engage snaps the low-pass
+        }
+
+        const Vector3 right = basis_rotation.rotate(Vector3{1.0f, 0.0f, 0.0f});
+        const Vector3 forward = basis_rotation.rotate(Vector3{0.0f, 1.0f, 0.0f});
+        const Vector3 up = basis_rotation.rotate(Vector3{0.0f, 0.0f, 1.0f});
         GameStructures::Matrix34f *matrix = reinterpret_cast<GameStructures::Matrix34f *>(camera);
         // Per-preset FOV, smoothly crossing the "off" boundary. SetFrustum (sub_1805392FC) writes the render
         // CCamera's FOV scalar at camera+0x30 right before this builder, plus the cull-frustum edge vectors at
@@ -890,8 +987,9 @@ namespace TPVCamera
         // the captured heading plus any orbit the player has added since capture. On the capture frame the body
         // has not turned yet, so this equals the pre-move orbit (no snap); as the eye+body rotate to the heading
         // the angle eases to the residual orbit, so the camera POSITION is identical across the turn (no pop).
-        // forward is the untouched eye look (read at frame start), so it tracks the body one frame behind --
-        // exactly in step with the body-turn's own one-frame apply latency. cam.orbit_yaw stays the raw input
+        // forward is this frame's rig basis forward (the stable-aim or smoothed basis when active, else the raw
+        // eye look); char_forward_yaw below derives from the SAME forward that positions the camera, so the two
+        // cancel and the held world yaw is independent of which source forward tracks. cam.orbit_yaw stays the raw input
         // accumulator throughout; the rendered angle is baked back only on release/stop so free-look resumes
         // from exactly where the moving camera was. orbit_moving implies the key was held, so this also runs on
         // the release frame (orbit_moving is cleared at end of frame), giving the bake-on-release below.
@@ -1748,14 +1846,28 @@ namespace TPVCamera
         // col2 = up) so the orientation transitions smoothly too.
         // Screen-centre forward (the crosshair direction): the converged/orbited look when we rebuilt the
         // basis, else the engine eye forward. Published below for the camera-space interaction hook.
+        // When the stable / smoothed basis is active, the rendered ORIENTATION must be rebuilt from it too:
+        // otherwise the engine eye orientation (which carries the view-shake) would still drive the view
+        // rotation even though the position is now stable, leaving the view tilting during an action. Forcing
+        // the rebuild here routes the orientation through the same eye->stable blend below. When the basis was
+        // NOT overridden, eye_forward == forward and eye_up == up, so this is a no-op and the path stays
+        // byte-identical to the convergence/orbit-only behaviour.
+        if (basis_overridden)
+        {
+            rebuild_basis = true;
+        }
         Vector3 screen_forward = forward;
         if (rebuild_basis)
         {
-            Vector3 blended_forward = forward + (look_forward - forward) * view_blend;
+            // Blend the orientation from the engine EYE basis (FPV side, so view_blend 0 leaves the untouched
+            // first-person view) to the stable look (TPV side). At view_blend 0 this reconstructs the engine
+            // eye basis exactly (eye_forward x eye_up == eye_right); at view_blend 1 it is the stable look.
+            Vector3 blended_forward = eye_forward + (look_forward - eye_forward) * view_blend;
             blended_forward =
                 (blended_forward.magnitude_squared() > 1e-6f) ? blended_forward.normalized() : look_forward;
             screen_forward = blended_forward;
-            const Vector3 right_axis = blended_forward.cross(up);
+            const Vector3 ref_up = eye_up + (up - eye_up) * view_blend;
+            const Vector3 right_axis = blended_forward.cross(ref_up);
             if (right_axis.magnitude_squared() > 1e-6f)
             {
                 const Vector3 new_right = right_axis.normalized();
@@ -2130,6 +2242,7 @@ namespace TPVCamera
             cam.orbit_steer_valid = false; // and the continuous-align steer low-pass
             cam.eye_sync_valid = false;    // and the dynamic eye-height low-pass
             cam.fov_ease_valid = false;    // and the per-preset FOV override ease
+            cam.basis_quat_valid = false;  // and the aim-basis low-pass
             cam.orbit_moving = false;
             cam.orbit_target_valid = false;
             // Back to first person: the next engaged frame should snap the preset, not ease across the gap.

--- a/TPVCamera/src/offset_heal.cpp
+++ b/TPVCamera/src/offset_heal.cpp
@@ -48,6 +48,13 @@ namespace TPVCamera
             return std::min(static_cast<std::size_t>(configured), DMK::Rtti::MAX_HEAL_WINDOW);
         }
 
+        // Frame interval between self-heal retry scans for an offset that has not resolved yet (its target object
+        // is not constructed until a session loads, or the actor is not yet seated). The RTTI prelude is
+        // syscall-heavy, so a not-yet-live offset is retried on this cadence rather than every frame. There is NO
+        // attempt cap: however long the player lingers at the main menu or a load takes, the heal keeps retrying
+        // until the object appears, then latches and stops.
+        constexpr int k_heal_retry_interval_frames = 30; // about 0.5s at 60 FPS
+
         // Self-heal landmarks: "at this nominal offset within the struct there is a slot referring to an object of
         // this mangled type." Each is keyed on a type that is stable across patches (an engine/base type or an
         // already-trusted concrete type), per the rtti_dissect guidance. base is filled at call time. The
@@ -76,6 +83,9 @@ namespace TPVCamera
         constexpr DMK::Rtti::Landmark k_animchar_lm{.nominal_offset = Constants::ANIMATED_HUMAN_ANIMCHAR_OFFSET,
                                                     .expected_mangled = Constants::ANIMATED_CHARACTER_RTTI_NAME,
                                                     .indirection = DMK::Rtti::Indirection::PointerToObject};
+        constexpr DMK::Rtti::Landmark k_actiongame_lm{.nominal_offset = Constants::CCRYACTION_ACTIONGAME_OFFSET,
+                                                      .expected_mangled = Constants::CACTIONGAME_RTTI_NAME,
+                                                      .indirection = DMK::Rtti::Indirection::PointerToObject};
         constexpr DMK::Rtti::Landmark k_localactor_lm{.nominal_offset = Constants::CACTIONGAME_LOCAL_ACTOR_OFFSET,
                                                       .expected_mangled = Constants::C_PLAYER_RTTI_NAME,
                                                       .indirection = DMK::Rtti::Indirection::PointerToObject};
@@ -185,88 +195,156 @@ namespace TPVCamera
         return offsets;
     }
 
-    void heal_player_offsets(std::uintptr_t c_player) noexcept
+    void heal_framework_offset(std::uintptr_t cry_action) noexcept
     {
-        // One-shot: the first call on a validated C_Player heals; later calls return immediately. The heals run
-        // on the render thread inside the already-SEH-guarded resolve path, so a single guard is sufficient.
+        // Latch on SUCCESS, never on call count or an attempt cap: the CActionGame pointer at
+        // CCryAction+CCRYACTION_ACTIONGAME_OFFSET is null until the framework constructs it (cold boot, main
+        // menu, a slow load), so the heal must keep retrying for as long as that takes and stop only once it
+        // actually resolves.
         static std::atomic<bool> s_done{false};
-        bool expected = false;
-        if (!s_done.compare_exchange_strong(expected, true, std::memory_order_relaxed))
+        if (s_done.load(std::memory_order_relaxed))
         {
             return;
         }
+        RuntimeOffsets &offsets = runtime_offsets();
+        // Stay SILENT while CActionGame does not exist yet. If the slot reads a null/implausible pointer the
+        // object is simply not constructed (the normal pre-session state, e.g. the main menu); that is not a
+        // layout drift, so do not scan or log -- just return and try again on a later frame. This mirrors the
+        // populated-slot gate the resolver uses before walking the chain, and it keeps the per-frame menu path
+        // free of both the syscall-heavy RTTI prelude and any misleading "could not resolve" noise.
+        const auto action_game = DMK::Memory::seh_read<std::uintptr_t>(
+            cry_action + offsets.ccryaction_actiongame.load(std::memory_order_relaxed));
+        if (!action_game || !DMK::Memory::plausible_userspace_ptr(*action_game))
+        {
+            return;
+        }
+        // The slot is populated. Rate-limit the scan so a layout that genuinely cannot be recovered does not run
+        // the prelude every frame. heal_one logs a recovered drift loudly (warn_layout_drift_once) but treats a
+        // still-unresolvable populated slot as an expected miss (optional == true -> Debug, not a Warning), so a
+        // transition frame never emits the misleading "re-author" message.
+        static int s_frames_until_retry = 0;
+        if (s_frames_until_retry > 0)
+        {
+            --s_frames_until_retry;
+            return;
+        }
+        s_frames_until_retry = k_heal_retry_interval_frames;
+        if (heal_one("actionGame", k_actiongame_lm, cry_action, offsets.ccryaction_actiongame, true))
+        {
+            s_done.store(true, std::memory_order_relaxed);
+        }
+    }
+
+    void heal_player_offsets(std::uintptr_t c_player) noexcept
+    {
+        // Latch each group on its OWN success rather than one-shotting the whole batch on call count. The
+        // C_Player-direct landmarks resolve deterministically once the caller has validated the C_Player vtable,
+        // but animChar lives one hop out on C_AnimatedHuman, which can be briefly null on the first valid frame.
+        // A single entry latch would freeze animChar at nominal forever in that case; latching the two groups
+        // independently lets animChar heal on a later frame instead of being abandoned (no attempt cap).
+        static std::atomic<bool> s_direct_done{false};   // animatedHuman + actorModel + missileController + the bracket
+        static std::atomic<bool> s_animchar_done{false}; // one hop out via C_AnimatedHuman
+        if (s_direct_done.load(std::memory_order_relaxed) && s_animchar_done.load(std::memory_order_relaxed))
+        {
+            return;
+        }
+        // Rate-limit the retry: the RTTI prelude is syscall-heavy, so the unresolved group is re-attempted on a
+        // fixed cadence (never every frame) while C_AnimatedHuman comes up.
+        static int s_frames_until_retry = 0;
+        if (s_frames_until_retry > 0)
+        {
+            --s_frames_until_retry;
+            return;
+        }
+        s_frames_until_retry = k_heal_retry_interval_frames;
 
         RuntimeOffsets &offsets = runtime_offsets();
-        // These members key on types that are UNIQUE within C_Player, so an independent window scan cannot land
-        // on a wrong same-typed neighbour; they heal independently, which keeps each one resilient to a shift
-        // that is not uniform across the struct. (entity is handled by the corroborated bracket below instead:
-        // CEntity is a common type, so an independent scan would be decoy-prone.) The missile controller is
-        // embedded in C_Player (constructed in its ctor), so its RTTI is normally resolvable at all times and it
-        // heals like the rest; it is passed optional only defensively, so any weapon/inventory state that left
-        // its slot unresolvable degrades to a Debug note rather than a spurious drift Warning.
-        (void)heal_one("animatedHuman", k_animhuman_lm, c_player, offsets.c_player_animated_human, false);
-        (void)heal_one("actorModel", k_actormodel_lm, c_player, offsets.c_player_actor_model, false);
-        (void)heal_one("missileController", k_missile_lm, c_player, offsets.c_player_missile_controller, true);
-
-        // animChar lives one hop out, on C_AnimatedHuman, so resolve that pointer through the (now healed)
-        // animated-human offset before healing it. A missing C_AnimatedHuman just leaves the nominal in place.
         DMK::Logger &logger = DMK::Logger::get_instance();
-        const auto anim_human = DMK::Memory::seh_read<std::uintptr_t>(
-            c_player + offsets.c_player_animated_human.load(std::memory_order_relaxed));
-        if (anim_human && DMK::Memory::plausible_userspace_ptr(*anim_human))
-        {
-            (void)heal_one("animChar", k_animchar_lm, *anim_human, offsets.animated_human_animchar, false);
-        }
-        else
-        {
-            logger.debug("Self-heal: animChar skipped (C_AnimatedHuman not resolvable); keeping nominal {:#x}",
-                         Constants::ANIMATED_HUMAN_ANIMCHAR_OFFSET);
-        }
 
-        // Corroborated bracket: recover BOTH the entity pointer (common type, decoy-prone for a blind scan) and
-        // the look controller (no RTTI of its own) from the single top-of-struct delta that entity and
-        // HitDeathReactions both agree on (see k_player_top_bracket). Each rides the delta on success; a
-        // non-uniform shift fails the solve and both stay nominal (fail-closed).
-        const auto fit = DMK::Rtti::solve_fingerprint(c_player, k_player_top_bracket, heal_window());
-        if (fit)
+        if (!s_direct_done.load(std::memory_order_relaxed))
         {
-            const std::ptrdiff_t entity_healed = Constants::C_PLAYER_ENTITY_OFFSET + fit->delta;
-            const std::ptrdiff_t look_healed = Constants::C_PLAYER_LOOK_CONTROLLER_OFFSET + fit->delta;
-            offsets.c_player_entity.store(entity_healed, std::memory_order_relaxed);
-            offsets.c_player_look_controller.store(look_healed, std::memory_order_relaxed);
-            if (fit->delta != 0)
+            // These members key on types that are UNIQUE within C_Player, so an independent window scan cannot
+            // land on a wrong same-typed neighbour; they heal independently, which keeps each one resilient to a
+            // shift that is not uniform across the struct. (entity is handled by the corroborated bracket below
+            // instead: CEntity is a common type, so an independent scan would be decoy-prone.) The missile
+            // controller is embedded in C_Player (constructed in its ctor), so its RTTI is normally resolvable.
+            // The C_Player vtable is already validated by the caller, so this group is deterministic on a valid
+            // frame and latches after one pass; a miss is logged at Debug (optional) since a recovered drift
+            // still warns loudly via heal_one's success path.
+            (void)heal_one("animatedHuman", k_animhuman_lm, c_player, offsets.c_player_animated_human, true);
+            (void)heal_one("actorModel", k_actormodel_lm, c_player, offsets.c_player_actor_model, true);
+            (void)heal_one("missileController", k_missile_lm, c_player, offsets.c_player_missile_controller, true);
+
+            // Corroborated bracket: recover BOTH the entity pointer (common type, decoy-prone for a blind scan)
+            // and the look controller (no RTTI of its own) from the single top-of-struct delta that entity and
+            // HitDeathReactions both agree on (see k_player_top_bracket). Each rides the delta on success; a
+            // non-uniform shift fails the solve and both stay nominal (fail-closed).
+            const auto fit = DMK::Rtti::solve_fingerprint(c_player, k_player_top_bracket, heal_window());
+            if (fit)
             {
-                warn_layout_drift_once(); // header before the moved lines (see heal_one)
-                logger.info("Self-heal: entity moved {:+#x} ({:#x} -> {:#x})", fit->delta,
-                            Constants::C_PLAYER_ENTITY_OFFSET, entity_healed);
-                logger.info("Self-heal: lookController moved {:+#x} ({:#x} -> {:#x})", fit->delta,
-                            Constants::C_PLAYER_LOOK_CONTROLLER_OFFSET, look_healed);
+                const std::ptrdiff_t entity_healed = Constants::C_PLAYER_ENTITY_OFFSET + fit->delta;
+                const std::ptrdiff_t look_healed = Constants::C_PLAYER_LOOK_CONTROLLER_OFFSET + fit->delta;
+                offsets.c_player_entity.store(entity_healed, std::memory_order_relaxed);
+                offsets.c_player_look_controller.store(look_healed, std::memory_order_relaxed);
+                if (fit->delta != 0)
+                {
+                    warn_layout_drift_once(); // header before the moved lines (see heal_one)
+                    logger.info("Self-heal: entity moved {:+#x} ({:#x} -> {:#x})", fit->delta,
+                                Constants::C_PLAYER_ENTITY_OFFSET, entity_healed);
+                    logger.info("Self-heal: lookController moved {:+#x} ({:#x} -> {:#x})", fit->delta,
+                                Constants::C_PLAYER_LOOK_CONTROLLER_OFFSET, look_healed);
+                }
+                else
+                {
+                    logger.debug("Self-heal: entity + lookController confirmed at nominal (entity {:#x}, "
+                                 "lookController {:#x})",
+                                 Constants::C_PLAYER_ENTITY_OFFSET, Constants::C_PLAYER_LOOK_CONTROLLER_OFFSET);
+                }
             }
             else
             {
-                logger.debug("Self-heal: entity + lookController confirmed at nominal (entity {:#x}, "
-                             "lookController {:#x})",
-                             Constants::C_PLAYER_ENTITY_OFFSET, Constants::C_PLAYER_LOOK_CONTROLLER_OFFSET);
+                // Bracket disagreed (non-uniform shift across the span). lookController has no RTTI of its own,
+                // so it cannot be recovered independently and stays nominal. entity CAN still be scanned for by
+                // type as a LAST RESORT: this reintroduces the decoy risk the corroborated solve avoided (a wrong
+                // same-typed CEntity neighbour could be picked), but a best-effort offset beats a guaranteed-stale
+                // one when the bracket has already failed, so try it. The solve is deterministic on a validated
+                // C_Player, so an undrifted build never reaches here; the diagnostic is logged at Debug.
+                logger.debug("Self-heal: bracket unresolved ({}); lookController kept nominal; entity via "
+                             "uncorroborated scan",
+                             DMK::Rtti::heal_error_to_string(fit.error()));
+                (void)heal_one("entity (uncorroborated fallback)", k_entity_lm, c_player, offsets.c_player_entity,
+                               true);
             }
+            s_direct_done.store(true, std::memory_order_relaxed);
         }
-        else
+
+        if (!s_animchar_done.load(std::memory_order_relaxed))
         {
-            // Bracket disagreed (non-uniform shift across the span). lookController has no RTTI of its own, so
-            // it cannot be recovered independently and stays nominal. entity CAN still be scanned for by type as
-            // a LAST RESORT: this reintroduces the decoy risk the corroborated solve avoided (a wrong same-typed
-            // CEntity neighbour could be picked), but a best-effort offset beats a guaranteed-stale one when the
-            // bracket has already failed, so try it and warn that the result is unverified.
-            logger.warning("Self-heal: bracket unresolved ({}); lookController kept nominal; entity via "
-                           "uncorroborated scan (decoy risk)",
-                           DMK::Rtti::heal_error_to_string(fit.error()));
-            (void)heal_one("entity (uncorroborated fallback)", k_entity_lm, c_player, offsets.c_player_entity, false);
+            // animChar lives one hop out, on C_AnimatedHuman, so resolve that pointer through the (healed)
+            // animated-human offset before healing it. While C_AnimatedHuman is still null (not yet constructed
+            // on this frame) leave animChar at nominal and retry on a later interval -- do NOT latch, so a brief
+            // null does not abandon the heal, and stay silent so the wait does not spam the log. Once
+            // C_AnimatedHuman is live the animChar result is deterministic, so attempt it once and latch.
+            const auto anim_human = DMK::Memory::seh_read<std::uintptr_t>(
+                c_player + offsets.c_player_animated_human.load(std::memory_order_relaxed));
+            if (anim_human && DMK::Memory::plausible_userspace_ptr(*anim_human))
+            {
+                (void)heal_one("animChar", k_animchar_lm, *anim_human, offsets.animated_human_animchar, true);
+                s_animchar_done.store(true, std::memory_order_relaxed);
+            }
         }
     }
 
     std::ptrdiff_t heal_local_actor_offset(std::uintptr_t action_game) noexcept
     {
         RuntimeOffsets &offsets = runtime_offsets();
-        (void)heal_one("localActor", k_localactor_lm, action_game, offsets.cactiongame_local_actor, false);
+        // The caller enters here only when the cached slot holds a populated object that is NOT a C_Player. That
+        // is the signature of a CActionGame layout drift, but it is ALSO the transient seen while the real player
+        // is still seating in during a load, so a miss is not necessarily drift -- it is logged at Debug
+        // (optional) rather than crying "re-author". A recovered drift still warns loudly via heal_one's success
+        // path. The caller rate-limits and never caps the retries, so a player that takes a long time to seat is
+        // simply re-scanned until it appears.
+        (void)heal_one("localActor", k_localactor_lm, action_game, offsets.cactiongame_local_actor, true);
         return offsets.cactiongame_local_actor.load(std::memory_order_relaxed);
     }
 
@@ -277,17 +355,20 @@ namespace TPVCamera
         // latch keyed on the manager would freeze the minigame member if it missed the latching frame) and never
         // rescans a member that already healed. The context base is anchored, so unlike the local-actor offset a
         // context-member drift IS recoverable here (the scan does not navigate through the offset it is healing).
-        // The caller gates this on the world being ready, when both subsystems are live.
+        // The caller gates this on the world being ready; a member that is briefly not yet live on that edge is
+        // an expected miss (optional == true -> Debug, never the misleading "re-author" Warning), while a
+        // recovered drift still warns loudly via heal_one. There is no attempt cap: each member keeps retrying
+        // (per-member latch) until it resolves.
         static std::atomic<bool> s_manager_done{false};
         static std::atomic<bool> s_minigame_done{false};
         RuntimeOffsets &offsets = runtime_offsets();
         if (!s_manager_done.load(std::memory_order_relaxed) &&
-            heal_one("cameraManager", k_manager_lm, context, offsets.context_manager, false))
+            heal_one("cameraManager", k_manager_lm, context, offsets.context_manager, true))
         {
             s_manager_done.store(true, std::memory_order_relaxed);
         }
         if (!s_minigame_done.load(std::memory_order_relaxed) &&
-            heal_one("minigameSubsystem", k_minigame_subsystem_lm, context, offsets.context_minigame_subsystem, false))
+            heal_one("minigameSubsystem", k_minigame_subsystem_lm, context, offsets.context_minigame_subsystem, true))
         {
             s_minigame_done.store(true, std::memory_order_relaxed);
         }

--- a/TPVCamera/src/offset_heal.hpp
+++ b/TPVCamera/src/offset_heal.hpp
@@ -42,6 +42,7 @@ namespace TPVCamera
      */
     struct RuntimeOffsets
     {
+        std::atomic<std::ptrdiff_t> ccryaction_actiongame{Constants::CCRYACTION_ACTIONGAME_OFFSET};
         std::atomic<std::ptrdiff_t> cactiongame_local_actor{Constants::CACTIONGAME_LOCAL_ACTOR_OFFSET};
         std::atomic<std::ptrdiff_t> c_player_entity{Constants::C_PLAYER_ENTITY_OFFSET};
         std::atomic<std::ptrdiff_t> c_player_look_controller{Constants::C_PLAYER_LOOK_CONTROLLER_OFFSET};
@@ -61,14 +62,28 @@ namespace TPVCamera
     [[nodiscard]] RuntimeOffsets &runtime_offsets() noexcept;
 
     /**
-     * @brief Heals the C_Player-rooted offsets once from a live, RTTI-validated C_Player.
-     * @details Independently heals the RTTI-typed members (entity, animated-human, actor-model, missile
-     *          controller) and the animated-character pointer one hop further out, then recovers the
-     *          look-controller offset (which has no RTTI of its own) from the tight bracket of its two
-     *          straddling RTTI neighbours. Each heal that resolves writes its cache field; each that cannot
-     *          leaves the nominal in place. One-shot: the first call on a validated C_Player does the work,
-     *          every later call returns immediately. Caller must pass a C_Player whose vtable already matched
-     *          C_PLAYER_RTTI_NAME (the members are only meaningful for a real C_Player). Render-thread only.
+     * @brief Heals the CCryAction -> CActionGame pointer offset once from the resolved CCryAction framework.
+     * @details This is the root of the player chain: every actor walk reads CActionGame through this offset
+     *          before any of the C_Player-rooted heals can run, so a CCryAction layout shift here would defeat
+     *          the whole chain. CActionGame carries RTTI (CACTIONGAME_RTTI_NAME), so the slot is healable by a
+     *          window scan keyed on that type. Latches on the first SUCCESS, never on call count: the slot reads
+     *          null until the framework constructs CActionGame (cold boot, main menu, a slow load), so the heal
+     *          stays silent and keeps retrying for as long as that takes, then stops once it resolves. Caller
+     *          passes the cached CCryAction (resolved via GetIGameFramework). Render-thread only.
+     * @param cry_action Live CCryAction framework base address.
+     */
+    void heal_framework_offset(std::uintptr_t cry_action) noexcept;
+
+    /**
+     * @brief Heals the C_Player-rooted offsets from a live, RTTI-validated C_Player; retries until resolved.
+     * @details Independently heals the RTTI-typed members whose type is UNIQUE within C_Player (animated-human,
+     *          actor-model, missile controller) and recovers the entity + look-controller offsets (the latter
+     *          has no RTTI of its own) from a corroborated top-of-struct bracket; the animated-character pointer
+     *          one hop further out is healed through the (healed) animated-human offset. The C_Player-direct
+     *          group is deterministic once the caller has validated the vtable, so it latches after one pass;
+     *          animChar latches separately once C_AnimatedHuman is live, so a frame where that pointer is briefly
+     *          null retries on a later interval instead of being abandoned (no attempt cap). Caller must pass a
+     *          C_Player whose vtable already matched C_PLAYER_RTTI_NAME. Render-thread only.
      * @param c_player Live C_Player base address.
      */
     void heal_player_offsets(std::uintptr_t c_player) noexcept;

--- a/TPVCamera/src/physics_raycast.cpp
+++ b/TPVCamera/src/physics_raycast.cpp
@@ -223,7 +223,7 @@ namespace TPVCamera
         alignas(16) std::byte sphere[Constants::PRIMITIVE_SPHERE_SIZE];
         std::memset(sphere, 0, sizeof(sphere));
         *reinterpret_cast<Vector3 *>(sphere + 0x0) = origin;
-        *reinterpret_cast<float *>(sphere + 0xC) = radius;
+        *reinterpret_cast<float *>(sphere + Constants::PRIMITIVE_SPHERE_RADIUS_OFFSET) = radius;
 
         // geom_contact*; the engine writes through ppcontact, but we read only the float return (distance),
         // so we never dereference the contact (no shared-data lifetime concern).
@@ -239,7 +239,7 @@ namespace TPVCamera
         // contacts. This field is NOT standard rwi pierceability -- 0x40F
         // (rwi_stop_at_pierceable|colltype_any) hit only FAR geometry (missed close walls), and 0 registered NO
         // contacts at all.
-        *reinterpret_cast<int *>(params + Constants::SPWI_OFF_FLAGS) = 0x101;
+        *reinterpret_cast<int *>(params + Constants::SPWI_OFF_FLAGS) = Constants::SPWI_FLAGS_FULL_RANGE;
         // entTypes @+0x9C is DEAD in this fork: the impl (sub_1808182A0) has ZERO reads of +0x9C, so the sphere
         // ALWAYS queries ent_all and CANNOT be type-filtered here -- this write is a defensive no-op (harmless,
         // kept in case a future build wires the field up). Actors (player body/gear, NPCs) are NOT excluded here;
@@ -250,7 +250,7 @@ namespace TPVCamera
         *reinterpret_cast<int *>(params + Constants::SPWI_OFF_GEOMFLAGSALL) = 0;
         // Broad collision-type mask so the sphere stops on any solid surface (mirrors the RWI colltype_any
         // intent). A wrong value here only changes which parts block (functional, not a safety issue).
-        *reinterpret_cast<int *>(params + Constants::SPWI_OFF_GEOMFLAGSANY) = 0x0FFF;
+        *reinterpret_cast<int *>(params + Constants::SPWI_OFF_GEOMFLAGSANY) = Constants::SPWI_GEOMFLAGS_ANY_SOLID;
         // Skip the player's own physics entities (resolved by the caller via resolve_player_physics_skip), so
         // the sweep ignores the body/shield/gear and reports a clean WORLD distance. nSkipEnts is impl-clamped
         // to <=4; pSkipEnts is read as pSkipEnts[i] (an array of IPhysicalEntity*). Both offsets impl-confirmed.


### PR DESCRIPTION
## Summary

Adds two camera-stability options and hardens the mod so it keeps working after game updates.

- Stable Aim Basis and Aim Basis Smoothing keep the third-person view steady against head-bob, weapon sway, and combat shake. Both default on and are tunable live in the INI.
- The offset self-heal now retries until its target exists and recovers the framework root offset, so a game patch that shifts a struct is corrected at runtime instead of silently breaking.
- The context and input-dispatch AOB signatures were rewritten and verified to match the live retail build uniquely.
- Named the remaining magic offsets and updated the README, INI, BBCode, and changelog.
