### PR TITLE
chore(tpvcamera): upgrade DetourModKit to v3.9.0

### DIFF
--- a/TPVCamera/docs/NEXT_CHANGELOG.md
+++ b/TPVCamera/docs/NEXT_CHANGELOG.md
@@ -8,3 +8,4 @@
 - Collision now follows your real size and pose, so crouching, lying down, or riding no longer over-tightens the view
 - Made the camera smoother when moving through tight or cluttered areas
 - The cloth-roof clamp now also ignores thin props you can clearly see past
+- Updated the bundled modding toolkit (DetourModKit) to v3.9.0 for extra stability and future compatibility

--- a/TPVCamera/src/config.cpp
+++ b/TPVCamera/src/config.cpp
@@ -2,22 +2,18 @@
  * @file config.cpp
  * @brief Configuration registration for the TPV Camera mod using DMK::Config.
  *
- * Registration order is: log level, LiveSettings atomics, then the zoom
- * hold-binding key lists. Press bindings (view toggle, force FPV/TPV, orbit) are
- * registered separately (see tpv_camera.cpp). DMK::Config::load() / log_all() are
- * driven by the mod lifecycle once every item is registered.
+ * Registration order is: log level, then the LiveSettings atomics and the state-policy
+ * strings. The input bindings (press and hold) are registered separately by the mod
+ * lifecycle in tpv_camera.cpp, since their callbacks act on the camera state.
+ * DMK::Config::load() / log_all() are driven by the lifecycle once every item is registered.
  */
 
 #include "config.hpp"
 #include "constants.hpp"
 #include "game_state.hpp"
-#include "hooks/camera_hook.hpp"
 #include "presets/camera_preset.hpp"
 
 #include <DetourModKit.hpp>
-
-// Process-wide init-only configuration, shared with the hooks.
-Config g_config;
 
 namespace TPVCamera
 {
@@ -74,20 +70,6 @@ namespace TPVCamera
         // Free-look orbit (non-preset, always-live; the orbit feel values are per-preset).
         DMK::Config::register_atomic<bool>("Orbit", "FreezeOrbitOnCursor", "Freeze Orbit On Cursor",
                                            s.freeze_orbit_on_cursor, true);
-        // OrbitHoldKey is the MOMENTARY free-look key (freelook): hold it to engage the orbit and release
-        // it to return to the precise camera-aim view, separate from the press-to-toggle OrbitToggleKey.
-        // It is a hold binding, so (like the zoom keys) the list is stashed in g_config for
-        // register_hold_bindings to consume once, and the setter re-binds the live hold in place on a
-        // hot-reload via update_binding_combos (see ZoomInKey for why that second call is needed). Empty
-        // by default so it is opt-in and never collides with a game key or the toggle binding.
-        DMK::Config::register_key_combo(
-            "Orbit", "OrbitHoldKey", "Orbit Hold Key",
-            [](const DMK::Config::KeyComboList &c)
-            {
-                g_config.orbit_hold_keys = c;
-                DMK::InputManager::get_instance().update_binding_combos(k_orbit_hold_binding, c);
-            },
-            "");
 
         // Camera collision (non-preset, always-live; Enable/Skin/ReturnSpeed are per-preset). UseCoverageCollision
         // is the master switch for the coverage gate and the lateral probe (render occlusion is independent); OFF
@@ -140,30 +122,6 @@ namespace TPVCamera
         // switching presets on a state edge.
         DMK::Config::register_atomic<float>("Presets", "PresetBlendSpeed", "Preset Blend Speed", s.preset_blend_speed,
                                             8.0f);
-
-        // Zoom hold keys (the detour polls them by name each frame to drive the follow distance).
-        // Defaults: LShift+PageUp / LShift+PageDown on keyboard, or hold LB + D-pad up/down on a controller.
-        // The setters keep g_config in sync (read once by register_hold_bindings to create the InputManager
-        // hold binding) AND call update_binding_combos so a hot-reload of the keys re-binds the live hold in
-        // place. Without that second call the reload would update g_config but leave the hold binding on its
-        // startup keys, so editing ZoomIn/OutKey would not apply until restart (unlike the press combos, whose
-        // register_press_combo already re-binds on reload).
-        DMK::Config::register_key_combo(
-            "Camera", "ZoomInKey", "Zoom In Key",
-            [](const DMK::Config::KeyComboList &c)
-            {
-                g_config.zoom_in_keys = c;
-                DMK::InputManager::get_instance().update_binding_combos(k_zoom_in_binding, c);
-            },
-            "LShift+PageUp,Gamepad_LB+Gamepad_DpadUp");
-        DMK::Config::register_key_combo(
-            "Camera", "ZoomOutKey", "Zoom Out Key",
-            [](const DMK::Config::KeyComboList &c)
-            {
-                g_config.zoom_out_keys = c;
-                DMK::InputManager::get_instance().update_binding_combos(k_zoom_out_binding, c);
-            },
-            "LShift+PageDown,Gamepad_LB+Gamepad_DpadDown");
     }
 
 } // namespace TPVCamera

--- a/TPVCamera/src/config.hpp
+++ b/TPVCamera/src/config.hpp
@@ -2,42 +2,18 @@
  * @file config.hpp
  * @brief Configuration model and registration for the TPV Camera mod.
  *
- * @details Settings split by access pattern:
- *          - LiveSettings holds every value read on a hot path (the per-frame
- *            detour) or across threads. They are std::atomic so INI hot-reload
- *            (which runs the setters on the ConfigWatcher thread) never races the
- *            game thread. They are bound with DMK::Config::register_atomic.
- *          - Config holds the key-combo lists for the hold bindings (zoom and the
- *            momentary free-look orbit), parsed by DMK::Config and consumed once when
- *            the InputManager hold bindings are registered. The press bindings (view
- *            toggle, force FPV/TPV, orbit toggle) are registered separately via
- *            DMK::Config::register_press_combo.
+ * @details LiveSettings holds every value read on a hot path (the per-frame detour) or across
+ *          threads. They are std::atomic so INI hot-reload (which runs the setters on the
+ *          ConfigWatcher thread) never races the game thread, and are bound with
+ *          DMK::Config::register_atomic. The input bindings (press and hold, including their key
+ *          combos) are registered separately in tpv_camera.cpp via DMK::Config::register_press_combo /
+ *          register_hold_combo.
  */
 #ifndef TPVCAMERA_CONFIG_HPP
 #define TPVCAMERA_CONFIG_HPP
 
-#include <DetourModKit.hpp>
-
 #include <atomic>
 #include <cstdint>
-
-/**
- * @struct Config
- * @brief Key lists for the hold bindings (zoom and momentary free-look orbit).
- */
-struct Config
-{
-    // Hold-binding key lists (parsed by DMK::Config; consumed once when the InputManager hold
-    // bindings are registered). The detour queries the zoom lists by name per frame to drive the
-    // follow distance; the orbit-hold list instead drives a momentary free-look engage on the press
-    // edge and a release on the release edge (register_hold is edge-triggered), so it is never polled.
-    DMK::Config::KeyComboList zoom_in_keys;
-    DMK::Config::KeyComboList zoom_out_keys;
-    DMK::Config::KeyComboList orbit_hold_keys;
-};
-
-/** @brief Process-wide init-only configuration (defined in config.cpp). */
-extern Config g_config;
 
 namespace TPVCamera
 {
@@ -217,10 +193,9 @@ namespace TPVCamera
     [[nodiscard]] LiveSettings &settings() noexcept;
 
     /**
-     * @brief Registers every non-press configuration item with DMK::Config.
-     * @details Registers the log level, the LiveSettings atomics, and the zoom
-     *          hold-binding key lists. Must be called before DMK::Config::load().
-     *          Press bindings are registered separately.
+     * @brief Registers the log level, the LiveSettings atomics, and the state-policy strings with DMK::Config.
+     * @details Must be called before DMK::Config::load(). The input bindings (press and hold) are
+     *          registered separately in tpv_camera.cpp.
      */
     void register_config_items();
 

--- a/TPVCamera/src/tpv_camera.cpp
+++ b/TPVCamera/src/tpv_camera.cpp
@@ -30,14 +30,17 @@
 
 #include <chrono>
 #include <functional>
+#include <optional>
 #include <string_view>
 #include <vector>
 
 namespace TPVCamera
 {
 
-    // RAII guards for the press bindings registered via DMK::Config::register_press_combo
-    // (cleared during shutdown so the callbacks cannot run during teardown).
+    // RAII guards for the input bindings registered via DMK::Config::register_press_combo /
+    // register_hold_combo. Cleared during shutdown so the callbacks cannot run during teardown; a
+    // still-held hold-combo guard additionally delivers one balancing on_state_change(false) on clear,
+    // so a torn-down orbit hold cannot strand free-look on.
     static std::vector<DMK::Config::InputBindingGuard> s_binding_guards;
 
     /**
@@ -263,60 +266,74 @@ namespace TPVCamera
     }
 
     /**
-     * @brief Registers the hold bindings (and the zoom triggers' optional INI consume flags) before load().
-     * @details DMK has no hold-combo helper, so the holds are created here from g_config (seeded with the
-     *          default combos by register_config_items); DMK::Config::load() then applies the INI combos
-     *          via update_binding_combos, the same way the press combos rebind on load. The zoom callbacks
-     *          are empty -- the frustum-builder detour queries their hold state by name each frame to drive
-     *          the follow distance. The orbit-hold callback instead engages/releases free-look directly on
-     *          its key edges (momentary freelook), so nothing polls it per frame.
+     * @brief Registers the hold bindings, fusing each INI key with its InputManager
+     *        hold binding via DMK::Config::register_hold_combo.
+     * @details Mirrors register_press_bindings: each returned guard is stashed in s_binding_guards so
+     *          the callback stays live until shutdown clears it. register_hold_combo carries the default
+     *          combo, rebinds the live hold on every INI reload (update_binding_combos), and -- on the
+     *          zoom triggers -- registers the optional "<key>.Consume" passthrough-suppression flag. The
+     *          zoom callbacks are empty: the frustum-builder detour queries their hold state by name each
+     *          frame to drive the follow distance. The orbit-hold callback instead engages/releases
+     *          free-look on its key edges (momentary freelook), so nothing polls it per frame.
      */
     static void register_hold_bindings()
     {
-        DMK::InputManager &input_mgr = DMK::InputManager::get_instance();
-        input_mgr.register_hold(k_zoom_in_binding, g_config.zoom_in_keys, [](bool) {});
-        input_mgr.register_hold(k_zoom_out_binding, g_config.zoom_out_keys, [](bool) {});
+        auto add_hold = [](std::string_view section, std::string_view ini_key, std::string_view log_name,
+                           std::string_view binding, std::function<void(bool)> on_state_change,
+                           std::string_view default_combo, std::optional<bool> consume)
+        {
+            s_binding_guards.push_back(DMK::Config::register_hold_combo(
+                section, ini_key, log_name, binding, std::move(on_state_change), default_combo, consume));
+        };
 
-        // Passthrough suppression for the gamepad zoom triggers, on by default and toggled per binding from
-        // the INI (ZoomInKey.Consume / ZoomOutKey.Consume). While enabled, DMK masks just the bound D-pad
-        // button out of the XInput state the game reads, so the LB + D-pad up/down zoom combo does not also
-        // fire the game's inventory/map shortcut as the gesture ends. Only the trigger button is masked
-        // (never the LB modifier, and keyboard zoom is never affected), and the mask is latched to the
-        // physical D-pad release plus a short grace window, so releasing LB a frame early cannot leak a
-        // bare D-pad press. Registered after the holds they target and before DMK::Config::load(), so the
-        // INI value lands on an existing binding at load and on every reload.
-        DMK::Config::register_consume_flag("Camera", "ZoomInKey.Consume", "Zoom In Consume", k_zoom_in_binding, true);
-        DMK::Config::register_consume_flag("Camera", "ZoomOutKey.Consume", "Zoom Out Consume", k_zoom_out_binding,
-                                           true);
+        // Zoom hold keys. Defaults: LShift+PageUp / LShift+PageDown on keyboard, or hold LB + D-pad
+        // up/down on a controller. The callbacks are empty because the frustum-builder detour polls the
+        // hold state by name each frame (is_binding_active) to drive the follow distance. Consume is on by
+        // default and toggled per binding from the INI (ZoomInKey.Consume / ZoomOutKey.Consume): while
+        // enabled, DMK masks just the bound D-pad button out of the XInput state the game reads, so the LB
+        // + D-pad up/down zoom combo does not also fire the game's inventory/map shortcut as the gesture
+        // ends. Only the trigger button is masked (never the LB modifier, and keyboard zoom is never
+        // affected), and the mask is latched to the physical D-pad release plus a short grace window, so
+        // releasing LB a frame early cannot leak a bare D-pad press.
+        add_hold(
+            "Camera", "ZoomInKey", "Zoom In Key", k_zoom_in_binding, [](bool) {},
+            "LShift+PageUp,Gamepad_LB+Gamepad_DpadUp", true);
+        add_hold(
+            "Camera", "ZoomOutKey", "Zoom Out Key", k_zoom_out_binding, [](bool) {},
+            "LShift+PageDown,Gamepad_LB+Gamepad_DpadDown", true);
 
-        // Momentary free-look (freelook, as in ArmA / DayZ / PUBG): hold OrbitHoldKey to engage the
-        // orbit and release to return to the precise camera-aim view. register_hold fires the callback
-        // with true on the press edge and false on release (and false at shutdown for an active hold),
-        // so the press engages and the release disengages. s_engaged_by_hold records whether THIS hold
-        // turned orbit on, so the release only undoes what the hold engaged: if orbit was already
-        // toggled on via OrbitToggleKey, the press is a no-op and the release leaves it on. The engage
-        // is gated on the UI like the toggle; the release is always honoured (even under UI) so a
-        // momentary orbit can never get stuck on. The callback runs only on the input poll thread (and,
-        // for the shutdown release, after that thread has joined), so the static needs no lock.
-        input_mgr.register_hold(k_orbit_hold_binding, g_config.orbit_hold_keys,
-                                [](bool pressed)
-                                {
-                                    static bool s_engaged_by_hold = false;
-                                    if (pressed)
-                                    {
-                                        if (is_ui_blocking_input() || camera_state().orbit_active.load())
-                                            return;
-                                        orbit_engage();
-                                        s_engaged_by_hold = true;
-                                        DMK::Logger::get_instance().info("Orbit camera ENABLED (hold)");
-                                    }
-                                    else if (s_engaged_by_hold)
-                                    {
-                                        orbit_disengage();
-                                        s_engaged_by_hold = false;
-                                        DMK::Logger::get_instance().info("Orbit camera DISABLED (hold released)");
-                                    }
-                                });
+        // Momentary free-look (freelook, as in ArmA / DayZ / PUBG): hold OrbitHoldKey to engage the orbit
+        // and release to return to the precise camera-aim view, separate from the press-to-toggle
+        // OrbitToggleKey. Empty default so it is opt-in and never collides with a game key. The combo fires
+        // the callback with true on the press edge and false on release; the returned guard also synthesizes
+        // one balancing false if the hold is still held when shutdown clears the guard, so a torn-down hold
+        // cannot strand orbit on. s_engaged_by_hold records whether THIS hold turned orbit on, so the
+        // release only undoes what the hold engaged: if orbit was already toggled on via OrbitToggleKey, the
+        // press is a no-op and the release leaves it on. The engage is gated on the UI like the toggle; the
+        // release is always honoured (even under UI) so a momentary orbit can never get stuck on. The guard
+        // serializes its synthesized release against any in-flight poll-thread delivery, so the static needs
+        // no lock.
+        add_hold(
+            "Orbit", "OrbitHoldKey", "Orbit Hold Key", k_orbit_hold_binding,
+            [](bool pressed)
+            {
+                static bool s_engaged_by_hold = false;
+                if (pressed)
+                {
+                    if (is_ui_blocking_input() || camera_state().orbit_active.load())
+                        return;
+                    orbit_engage();
+                    s_engaged_by_hold = true;
+                    DMK::Logger::get_instance().info("Orbit camera ENABLED (hold)");
+                }
+                else if (s_engaged_by_hold)
+                {
+                    orbit_disengage();
+                    s_engaged_by_hold = false;
+                    DMK::Logger::get_instance().info("Orbit camera DISABLED (hold released)");
+                }
+            },
+            "", std::nullopt);
     }
 
     /**


### PR DESCRIPTION
## Summary
Upgrades the TPVCamera DetourModKit submodule from v3.8.2 to v3.9.0 and adopts its new register_hold_combo API to consolidate the input hold bindings.

## Changes
- Bump the DetourModKit submodule to v3.9.0.
- Fuse the three hold bindings (zoom in, zoom out, orbit hold) onto register_hold_combo, matching the existing press-combo pattern and lifecycle.
- Remove the now-dead Config struct and g_config global, the stale "no hold-combo helper" workaround, and config.hpp's unused DetourModKit umbrella include.

